### PR TITLE
 Update test card number range

### DIFF
--- a/brands/README.md
+++ b/brands/README.md
@@ -1,15 +1,17 @@
 ## Brands
 
-After creating a FIDEL API account and have access to the dashboard, the next step is to create a test **Brand** so you can create locations and add them to a Program in order to generate transaction data.
+After creating a FIDEL API account and have access to the dashboard, the next step is to create a test **Brand** so you can create locations and add them to a Program in order to start tracking transactions.
 
-The **Brand** object is used to aggregate locations and keep a status of the brand consent. The consent is an signed authorization from the Brand that gives permission to FIDEL to monitor transactions in the Brand's locations. Once you go live you can request the Brand consent form from [developer@fidel.uk](mailto:developer@fidel.uk).
+The **Brand** (Merchant) object is used to aggregate locations and keep the status of the Brand consent. One of the requirements, when creating a Brand and before adding locations, is to obtain Brand consent from an authorized personnel (Brand User) and to provide the Brand with access to view the transactional data that is being shared.
 
-You can only create new locations on live environment from Brands that have signed the consent. On test environment, the consent status is automatically set to signed so you can continue testing.
-
-When you're live you should send the signed brand consent forms to [developer@fidel.uk](mailto:developer@fidel.uk). Usually we approve and set the Brand to signed status in less that 24h.
+You can only create new locations on live environment from Brands that you have invited to create an account have access to their card linked transactions. On test environment, the consent status is automatically approved so you can continue testing.
 
 # Create Brand
 To create a new Brand, go to the **Brands** page on the dashboard, click the **+** icon and enter a name. Optionally, you can add a link to the brand logo.
+
+To automatically request Brand consent, enter the name and email of the Brand User and will send an email inviting the Brand User to create a Brand account at [clo.fidel.uk](https://clo.fidel.uk) By creating an account the Brand User provides consent and will have access to transactions made by cardholders at their participating locations.
+
+You can monitor consent status on the dashboard and also set up a **brand.consent** webhook to be notified when the status changes.
 
 <h5>Go to the Brands page on the dashboard to create a new brand.</h5>
 


### PR DESCRIPTION
Update docs to reflect extended test card range.

Now 1000 test cards can be added per scheme (as opposed to 10/scheme previously):

- Full `5555000000005***` range for mc
- Full `4444000000004***` range for visa

This allows better testing, e.g. pagination.