### PR TITLE
[JO-246] Add full list of parameters to web sdk 3 documentation [PATCH]

### DIFF
--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -546,7 +546,6 @@ Fidel.openForm({
             privacyUrl: string,
             termsUrl: string,
             deleteInstructions: string,
-            travelAndExpensesPlatform: string,
             checkbox: {
                 style: CSSPropertiesObject,
                 checkedStyle: CSSPropertiesObject,
@@ -561,26 +560,6 @@ Fidel.openForm({
             defaultText: string,
             loadingText: string,
             successText: string,
-        },
-        verificationIntro: {
-            buttonText: string,
-            title: string,
-            description: string,
-        },
-        verifyCard: {
-            title: string,
-            description: string,
-            subDescription: string,
-            reconnectCardText: string,
-            submit: {
-              style: CSSPropertiesObject,
-              hoverStyle: CSSPropertiesObject,
-              loadingStyle: CSSPropertiesObject,
-              successStyle: CSSPropertiesObject,
-              defaultText: string,
-              loadingText: string,
-              successText: string,
-            },
         },
     }
 })

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -129,17 +129,17 @@ const label = {
 </thead>
 <tbody>
   <tr>
-    <td><code>companyName</code> (required)</td>
+    <td><code>companyName</code><br /><strong>required</strong></td>
     <td>string</td>
     <td>The name of the company using card linking.</td>
   </tr>
   <tr>
-    <td><code>sdkKey</code> (required)</td>
+    <td><code>sdkKey</code><br /><strong>required</strong></td>
     <td>string</td>
     <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with `pk_`.</td>
   </tr>
   <tr>
-    <td><code>programId</code> (required)</td>
+    <td><code>programId</code><br /><strong>required</strong></td>
     <td>string</td>
     <td>The id of the Fidel API Program to link the card to.</td>
   </tr>
@@ -147,11 +147,6 @@ const label = {
     <td><code>programName</code></td>
     <td>string</td>
     <td>The name of the Fidel API Program to link the card to.</td>
-  </tr>
-  <tr>
-    <td><code>programType</code></td>
-    <td>string<br /><em>Possible values: 'select-transaction', 'transaction-select', 'transaction-stream'</em></td>
-    <td>The type of the Fidel API Program to link the card to.</td>
   </tr>
   <tr>
     <td><code>callback</code></td>
@@ -170,7 +165,7 @@ const label = {
   </tr>
   <tr>
     <td><code>language</code></td>
-    <td>string<br /><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br />Default value: 'EN'</td>
+    <td>string<br /><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br /><em>Default value: 'EN'</em></td>
     <td>The language to be displayed. It follows `window.navigator.language` language codes.</td>
   </tr>
   <tr>
@@ -375,14 +370,6 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
     <td>Text to inform the user about how to opt out from the transaction monitoring. It is appended to the text "You may opt out of transaction monitoring on the payment card you entered at any time by".</td>
   </tr>
   <tr>
-    <td><code>terms.travelAndExpensesPlatform</code></td>
-    <td>
-      string<br />
-      <em>Default value: "my T&amp;E Platform"</em>
-    </td>
-    <td>Text of the Travel and Expenses Platform.</td>
-  </tr>
-  <tr>
     <td><code>terms.checkbox</code></td>
     <td>
       <code>style</code>: CSS properties<br />
@@ -408,40 +395,6 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
       <code>successText</code>: string
     </td>
     <td>Parameters to customize the CTA button on the screens of the card verification.</td>
-  </tr>
-  <tr>
-    <td><code>verificationIntro</code></td>
-    <td>
-      <code>buttonText</code>: string<br />
-      <em>Default value: "Continue"</em><br />
-      <code>title</code>: string<br />
-      <em>Default value: "Get started"</em><br />
-      <code>description</code>: string<br />
-      <em>Default value: "For identity verification purposes, we will send a microcharge (immediately refunded) to the card you connect. 
-          To connect and verify your card, follow these steps:"</em>
-    </td>
-    <td>Parameters to customize the first screen of the card verification.</td>
-  </tr>
-  <tr>
-    <td><code>verifyCard</code></td>
-    <td>
-      <code>title</code>: string<br />
-      <em>Default value: "Verify your card"</em><br />
-      <code>description</code>: string<br />
-      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact &#123;&#123;currency&#125;&#125; amount here within 48 hours."</em><br />
-      <code>subDescription</code>: string<br />
-      <em>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."</em><br />
-      <code>reconnectCardText</code>: string<br />
-      <em>Default value: "Reconnect your card"</em><br />
-      <code>submit.style</code>: CSS properties<br />
-      <code>submit.hoverStyle</code>: CSS properties<br />
-      <code>submit.loadingStyle</code>: CSS properties<br />
-      <code>submit.successStyle</code>: CSS properties<br />
-      <code>submit.defaultText</code>: string<br />
-      <em>Default value: Verify</em><br />
-      <code>submit.loadingText</code>: string<br />
-      <code>submit.successText</code>: string</td>
-    <td>Parameters to customize the second screen of the card verification.</td>
   </tr>
 </tbody>
 </table>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -129,67 +129,67 @@ const label = {
 </thead>
 <tbody>
   <tr>
-    <td>companyName (required)</td>
+    <td><code>companyName</code> (required)</td>
     <td>string</td>
     <td>The name of the company using card linking.</td>
   </tr>
   <tr>
-    <td>sdkKey (required)</td>
+    <td><code>sdkKey</code> (required)</td>
     <td>string</td>
     <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with `pk_`.</td>
   </tr>
   <tr>
-    <td>programId (required)</td>
+    <td><code>programId</code> (required)</td>
     <td>string</td>
     <td>The id of the Fidel API Program to link the card to.</td>
   </tr>
   <tr>
-    <td>programName</td>
+    <td><code>programName</code></td>
     <td>string</td>
     <td>The name of the Fidel API Program to link the card to.</td>
   </tr>
   <tr>
-    <td>programType<br><br> </td>
-    <td>string<br>Possible values: 'select-transaction', 'transaction-select',  'transaction-stream'</td>
+    <td><code>programType</code></td>
+    <td>string<br><em>Possible values: 'select-transaction', 'transaction-select', 'transaction-stream'</em></td>
     <td>The type of the Fidel API Program to link the card to.</td>
   </tr>
   <tr>
-    <td>callback</td>
+    <td><code>callback</code></td>
     <td>function</td>
     <td>Function to be called when the form is submitted.</td>
   </tr>
   <tr>
-    <td>container</td>
+    <td><code>container</code></td>
     <td>HTML element</td>
     <td>A wrapper element that you can wrap around the iframe.</td>
   </tr>
   <tr>
-    <td>countries</td>
-    <td>array of strings<br>Possible values: GBR, IRL, USA, SWE</td>
-    <td>If the array has only one value, that will be set as the country of issue for all collected Cards and the country select box is removed from the UI. If the array has multiple values, those will be the available options in the country select box.</td>
+    <td><code>countries</code></td>
+    <td>array of strings<br><em>Possible values: 'GBR', 'IRL', 'USA', 'SWE'</em></td>
+    <td>If the array has only one value, that will be set as the country of issue for all collected cards and the country select box is removed from the UI.<br>If the array has multiple values, those will be the available options in the country select box.</td>
   </tr>
   <tr>
-    <td>language</td>
-    <td>string<br>Possible values: EN, EN-BG, FR, JA, SV<br>Default value: EN</td>
+    <td><code>language</code></td>
+    <td>string<br><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br>Default value: 'EN'</td>
     <td>The language to be displayed. It follows `window.navigator.language` language codes.</td>
   </tr>
   <tr>
-    <td>metadata</td>
+    <td><code>metadata</code></td>
     <td>Record&lt;string, any&gt;</td>
     <td>The global metadata object. See more details in the next sections.</td>
   </tr>
   <tr>
-    <td>closeOnSuccess<br></td>
-    <td>boolean<br>Default value: true</td>
-    <td>Toggles the web form auto-close behavior on successful card linking.</td>
+    <td><code>closeOnSuccess</code></td>
+    <td>boolean<br><em>Default value: true</em></td>
+    <td>Toggles the form's auto-close behavior on successful card linking.</td>
   </tr>
   <tr>
-    <td>schemes.mastercard<br>schemes.visa<br>schemes.amex</td>
-    <td>boolean<br>By default, all three are true.</td>
+    <td><code>schemes.mastercard</code><br><code>schemes.visa</code><br><code>schemes.amex</code></td>
+    <td>boolean<br><em>By default, all three are true.</em></td>
     <td>Properties that toggle the availability of the Mastercard, Visa and Amex card schemes in the form.</td>
   </tr>
   <tr>
-    <td>custom</td>
+    <td><code>custom</code></td>
     <td>object</td>
     <td>Object that allows you to customize the UI for the Web SDK. You can find the structure for it in the customization section below.</td>
   </tr>
@@ -272,123 +272,175 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
 </thead>
 <tbody>
   <tr>
-    <td>logo.url</td>
+    <td><code>logo.url</code></td>
     <td>string</td>
     <td>The URL of the logo on the iframe.</td>
   </tr>
   <tr>
-    <td>logo.style</td>
+    <td><code>logo.style</code></td>
     <td>CSS properties</td>
     <td>The style of the logo on the iframe.</td>
   </tr>
   <tr>
-    <td>form.style</td>
+    <td><code>form.style</code></td>
     <td>CSS properties</td>
     <td>The style of the form element of the iframe.</td>
   </tr>
   <tr>
-    <td>overlay.style</td>
+    <td><code>overlay.style</code></td>
     <td>CSS properties</td>
     <td>The style of the overlay element of the iframe.</td>
   </tr>
   <tr>
-    <td>close.location</td>
-    <td>string<br>Possible values: form | overlay | none<br>Default value: overlay</td>
+    <td><code>close.location</code></td>
+    <td>
+      string<br>
+      <em>Possible values: form | overlay | none</em><br>
+      <em>Default value: overlay</em>
+    </td>
     <td>The location of the close icon.</td>
   </tr>
   <tr>
-    <td>close.color</td>
+    <td><code>close.color</code></td>
     <td>string</td>
     <td>The color of the close icon.</td>
   </tr>
   <tr>
-    <td>title.text</td>
-    <td>string<br>Default value: "Connect your card"</td>
+    <td><code>title.text</code></td>
+    <td>
+      string<br>
+      <em>Default value: "Connect your card"</em>
+    </td>
     <td>The text of the title at the top of the page.</td>
   </tr>
   <tr>
-    <td>title.style</td>
+    <td><code>title.style</code></td>
     <td>CSS properties</td>
     <td>The style of the title at the top of the page.</td>
   </tr>
   <tr>
-    <td>cardNumber.label</td>
+    <td><code>cardNumber.label</code></td>
     <td>LabelStyle (see definition below)</td>
     <td>The style of the Card Number label.</td>
   </tr>
   <tr>
-    <td>cardNumber.input</td>
+    <td><code>cardNumber.input</code></td>
     <td>InputStyle (see definition below)</td>
     <td>The style of the Card Number input field.</td>
   </tr>
   <tr>
-    <td>expiryDate.label</td>
+    <td><code>expiryDate.label</code></td>
     <td>LabelStyle (see definition below)</td>
     <td>The style of the Expiry Date label.</td>
   </tr>
   <tr>
-    <td>expiryDate.input</td>
+    <td><code>expiryDate.input</code></td>
     <td>InputStyle (see definition below)</td>
     <td>The style of the Expiry Date input field.</td>
   </tr>
   <tr>
-    <td>country.label</td>
+    <td><code>country.label</code></td>
     <td>LabelStyle (see definition below)</td>
     <td>The style of the Country field label.</td>
   </tr>
   <tr>
-    <td>country.input</td>
+    <td><code>country.input</code></td>
     <td>InputStyle (see definition below)</td>
     <td>The style of the Country input field.</td>
   </tr>
   <tr>
-    <td>terms.text</td>
-    <td>string<br>Default value: "I authorize {{scheme}} to monitor my payment card to identify transactions that qualify for a reward and for {{scheme}} to share such information with {{companyName}}, to enable my card linked offers and target offers that may be of interest to me."</td>
+    <td><code>terms.text</code></td>
+    <td>
+      string<br>
+      <em>Default value: "I authorize {{scheme}} to monitor my payment card to identify transactions that qualify for a reward and for {{scheme}} to share such information with {{companyName}}, to enable my card linked offers and target offers that may be of interest to me."</em>
+    </td>
     <td>The Terms of Use text.</td>
   </tr>
   <tr>
-    <td>terms.privacyUrl</td>
+    <td><code>terms.privacyUrl</code></td>
     <td>string</td>
     <td>The Privacy Policy URL.</td>
   </tr>
   <tr>
-    <td>terms.termsUrl</td>
+    <td><code>terms.termsUrl</code></td>
     <td>string</td>
     <td>The Terms and Conditions URL.</td>
   </tr>
   <tr>
-    <td>terms.deleteInstructions</td>
-    <td>string<br>Default value: "going to your account settings"</td>
+    <td><code>terms.deleteInstructions</code></td>
+    <td>
+      string<br>
+      <em>Default value: "going to your account settings"</em>
+    </td>
     <td>Text to inform the user about how to opt out from the transaction monitoring. It is appended to the text "You may opt out of transaction monitoring on the payment card you entered at any time by".</td>
   </tr>
   <tr>
-    <td>terms.travelAndExpensesPlatform</td>
-    <td>string<br>Default value: "my T&amp;E Platform"</td>
+    <td><code>terms.travelAndExpensesPlatform</code></td>
+    <td>
+      string<br>
+      <em>Default value: "my T&amp;E Platform"</em>
+    </td>
     <td>Text of the Travel and Expenses Platform.</td>
   </tr>
   <tr>
-    <td>terms.checkbox</td>
-    <td>style: CSS properties<br>checkedStyle: CSS properties</td>
+    <td><code>terms.checkbox</code></td>
+    <td>
+      <code>style</code>: CSS properties<br>
+      <code>checkedStyle</code>: CSS properties
+    </td>
     <td>The styles of the terms checkbox.</td>
   </tr>
   <tr>
-    <td>terms.checkbox.checkColor</td>
+    <td><code>terms.checkbox.checkColor</td>
     <td>string</td>
     <td>The border color of the terms checkbox.</td>
   </tr>
   <tr>
-    <td>submit</td>
-    <td>style: CSS properties<br>hoverStyle: CSS properties<br>loadingStyle: CSS properties<br>successStyle: CSS properties<br>defaultText: string<br>Default value: "Continue" | "Verify", depending on the step<br>loadingText: string<br>successText: string</td>
+    <td><code>submit</td>
+    <td>
+      <code>style</code>: CSS properties<br>
+      <code>hoverStyle</code>: CSS properties<br>
+      <code>loadingStyle</code>: CSS properties<br>
+      <code>successStyle</code>: CSS properties<br>
+      <code>defaultText</code>: string<br>
+      <em>Default value: "Continue" | "Verify", depending on the step</em><br>
+      <code>loadingText: string</code><br>
+      <code>successText: string</code>
+    </td>
     <td>Parameters to customize the CTA button on the screens of the card verification.</td>
   </tr>
   <tr>
-    <td>verificationIntro</td>
-    <td>buttonText: stringDefault value: "Continue"<br>title: string<br>Default value: "Get started"<br>description: string<br>Default value: "For identity verification purposes, we will send a microcharge (immediately refunded) to the card you connect. To connect and verify your card, follow these steps:"</td>
+    <td><code>verificationIntro</td>
+    <td>
+      <code>buttonText</code>: string<br>
+      <em>Default value: "Continue"</em><br>
+      <code>title</code>: string<br>
+      <em>Default value: "Get started"</em><br>
+      <code>description</code>: string<br>
+      <em>Default value: "For identity verification purposes, we will send a microcharge (immediately refunded) to the card you connect. 
+          To connect and verify your card, follow these steps:"</em>
+    </td>
     <td>Parameters to customize the first screen of the card verification.</td>
   </tr>
   <tr>
     <td>verifyCard</td>
-    <td>title: string<br>Default value: "Verify your card"<br>description: string<br>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."<br>subDescription: string<br>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."<br>reconnectCardText: string<br>Default value: "Reconnect your card"<br>submit.style: CSS properties<br>submit.hoverStyle: CSS properties<br>submit.loadingStyle: CSS properties<br>submit.successStyle: CSS properties<br>submit.defaultText: string<br>Default value: Verify<br>submit.loadingText: string<br>submit.successText: string</td>
+    <td>
+      <code>title</code>: string<br>
+      <em>Default value: "Verify your card"</em><br>
+      <code>description</code>: string<br>
+      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."</em><br>
+      <code>subDescription</code>: string<br>
+      <em>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."</em><br>
+      <code>reconnectCardText</code>: string<br>
+      <em>Default value: "Reconnect your card"</em><br>
+      <code>submit.style</code>: CSS properties<br>
+      <code>submit.hoverStyle</code>: CSS properties<br>
+      <code>submit.loadingStyle</code>: CSS properties<br>
+      <code>submit.successStyle</code>: CSS properties<br>
+      <code>submit.defaultText</code>: string<br>
+      <em>Default value: Verify</em><br>
+      <code>submit.loadingText</code>: string<br>
+      <code>submit.successText</code>: string</td>
     <td>Parameters to customize the second screen of the card verification.</td>
   </tr>
 </tbody>
@@ -406,27 +458,27 @@ LabelStyles
 </thead>
 <tbody>
   <tr>
-    <td>label.hide</td>
+    <td><code>label.hide</code></td>
     <td>CSS properties</td>
     <td>The default style of the input</td>
   </tr>
   <tr>
-    <td>label.style</td>
+    <td><code>label.style</code></td>
     <td>CSS properties</td>
     <td>The style of the input</td>
   </tr>
   <tr>
-    <td>label.errorStyle</td>
+    <td><code>label.errorStyle</code></td>
     <td>CSS properties</td>
     <td>The error style of the input</td>
   </tr>
   <tr>
-    <td>label.focusStyle</td>
+    <td><code>label.focusStyle</code></td>
     <td>CSS properties</td>
     <td>The focus style of the input</td>
   </tr>
   <tr>
-    <td>label.placeholderColor</td>
+    <td><code>label.placeholderColor</code></td>
     <td>string</td>
     <td>The color of the input's placeholder</td>
   </tr>
@@ -445,22 +497,22 @@ InputStyles
 </thead>
 <tbody>
   <tr>
-    <td>input.style</td>
+    <td><code>input.style</code></td>
     <td>CSS properties</td>
     <td>The default style of the input</td>
   </tr>
   <tr>
-    <td>input.errorStyle</td>
+    <td><code>input.errorStyle</code></td>
     <td>CSS properties</td>
     <td>The error style of the input</td>
   </tr>
   <tr>
-    <td>input.focusStyle</td>
+    <td><code>input.focusStyle</code></td>
     <td>CSS properties</td>
     <td>The focus style of the input</td>
   </tr>
   <tr>
-    <td>input.placeholderColor</td>
+    <td><code>input.placeholderColor</code></td>
     <td>string</td>
     <td>The color of the input's placeholder</td>
   </tr>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -119,72 +119,86 @@ const label = {
 
 #### Fidel Web SDK Parameters
 
-<dl>
-    <div>
-        <dt>
-            <span><code>companyName</code></span>
-		<strong>required</strong>
-        </dt>
-        <dd>the name of the company using card-linking</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>sdkKey</code></span>
-            <strong>required</strong>
-        </dt>
-        <dd>a valid SDK Key. You can find yours in the <a href="https://dashboard.fidel.uk/account/plan">Fidel Dashboard</a>. It starts with `pk_`.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>programId</code></span>
-            <strong>required</strong>
-        </dt>
-        <dd>the id of the Fidel Program to link the card to.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>callback</code></span>
-        </dt>
-        <dd>callback function to be called when the form is submitted</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>countries</code></span>
-            <em>Array with possible values: GBR, IRL, USA, SWE</em>
-        </dt>
-        <dd>when the array has only one entry, that is set as the country of issue for all Cards collected and the country select box is removed from the UI. If the array has multiple entries, those are the only ones available in the country select box.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>metadata</code></span>
-        </dt>
-        <dd>name of the global metadata object</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>closeOnSuccess</code></span>
-            <em>default: true</em>
-        </dt>
-        <dd>toggles the web form auto-close behaviour on successful card linking</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>schemes</code></span>
-            <em>object with boolean properties for mastercard, visa and amex. By default, all three are true.</em>
-        </dt>
-        <dd>toggles the availability of the Mastercard, Visa and Amex card schemes in the form</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>custom</code></span>
-        </dt>
-        <dd>object that allows you to customize the UI for the Web SDK. You can find the structure for it in the customization section below.</dd>
-    </div>
-</dl>
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>companyName (required)</td>
+    <td>string</td>
+    <td>The name of the company using card linking.</td>
+  </tr>
+  <tr>
+    <td>sdkKey (required)</td>
+    <td>string</td>
+    <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with `pk_`.</td>
+  </tr>
+  <tr>
+    <td>programId (required)</td>
+    <td>string</td>
+    <td>The id of the Fidel API Program to link the card to.</td>
+  </tr>
+  <tr>
+    <td>programName</td>
+    <td>string</td>
+    <td>The name of the Fidel API Program to link the card to.</td>
+  </tr>
+  <tr>
+    <td>programType<br><br> </td>
+    <td>string<br>Possible values: 'select-transaction', 'transaction-select',  'transaction-stream'</td>
+    <td>The type of the Fidel API Program to link the card to.</td>
+  </tr>
+  <tr>
+    <td>callback</td>
+    <td>function</td>
+    <td>Function to be called when the form is submitted.</td>
+  </tr>
+  <tr>
+    <td>container</td>
+    <td>HTML element</td>
+    <td>A wrapper element that you can wrap around the iframe.</td>
+  </tr>
+  <tr>
+    <td>countries</td>
+    <td>array of strings<br>Possible values: GBR, IRL, USA, SWE</td>
+    <td>If the array has only one value, that will be set as the country of issue for all collected Cards and the country select box is removed from the UI. If the array has multiple values, those will be the available options in the country select box.</td>
+  </tr>
+  <tr>
+    <td>language</td>
+    <td>string<br>Possible values: EN, EN-BG, FR, JA, SV<br>Default value: EN</td>
+    <td>The language to be displayed. It follows `window.navigator.language` language codes.</td>
+  </tr>
+  <tr>
+    <td>metadata</td>
+    <td>Record&lt;string, any&gt;</td>
+    <td>The global metadata object. See more details in the next sections.</td>
+  </tr>
+  <tr>
+    <td>closeOnSuccess<br></td>
+    <td>boolean<br>Default value: true</td>
+    <td>Toggles the web form auto-close behavior on successful card linking.</td>
+  </tr>
+  <tr>
+    <td>schemes.mastercard<br>schemes.visa<br>schemes.amex</td>
+    <td>boolean<br>By default, all three are true.</td>
+    <td>Properties that toggle the availability of the Mastercard, Visa and Amex card schemes in the form.</td>
+  </tr>
+  <tr>
+    <td>custom</td>
+    <td>object</td>
+    <td>Object that allows you to customize the UI for the Web SDK. You can find the structure for it in the customization section below.</td>
+  </tr>
+</tbody>
+</table>
 
 #### Fidel Web SDK Global Object
 
-After adding the Web SDK script on your website, a global variable `Fidel` is created with two methods that you can use to open and close the web form manually, `Fidel.openForm()` and `Fidel.closeForm()`. 
+After adding the Web SDK script on your website, a global variable `Fidel` is created with two methods that you can use to open and close the web form manually, `Fidel.openForm()` and `Fidel.closeForm()`.
 
 To open the iframe overlay form with a button, you could use this example:
 
@@ -246,7 +260,214 @@ document.getElementById("open-form").addEventListener("click", function() {
 
 ## Customizing the Web SDK
 
-The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of paramets, all of which are optional.
+The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of parameters, all of which are optional.
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>logo.url</td>
+    <td>string</td>
+    <td>The URL of the logo on the iframe.</td>
+  </tr>
+  <tr>
+    <td>logo.style</td>
+    <td>CSS properties</td>
+    <td>The style of the logo on the iframe.</td>
+  </tr>
+  <tr>
+    <td>form.style</td>
+    <td>CSS properties</td>
+    <td>The style of the form element of the iframe.</td>
+  </tr>
+  <tr>
+    <td>overlay.style</td>
+    <td>CSS properties</td>
+    <td>The style of the overlay element of the iframe.</td>
+  </tr>
+  <tr>
+    <td>close.location</td>
+    <td>string<br>Possible values: form | overlay | none<br>Default value: overlay</td>
+    <td>The location of the close icon.</td>
+  </tr>
+  <tr>
+    <td>close.color</td>
+    <td>string</td>
+    <td>The color of the close icon.</td>
+  </tr>
+  <tr>
+    <td>title.text</td>
+    <td>string<br>Default value: "Connect your card"</td>
+    <td>The text of the title at the top of the page.</td>
+  </tr>
+  <tr>
+    <td>title.style</td>
+    <td>CSS properties</td>
+    <td>The style of the title at the top of the page.</td>
+  </tr>
+  <tr>
+    <td>cardNumber.label</td>
+    <td>LabelStyle (see definition below)</td>
+    <td>The style of the Card Number label.</td>
+  </tr>
+  <tr>
+    <td>cardNumber.input</td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Card Number input field.</td>
+  </tr>
+  <tr>
+    <td>expiryDate.label</td>
+    <td>LabelStyle (see definition below)</td>
+    <td>The style of the Expiry Date label.</td>
+  </tr>
+  <tr>
+    <td>expiryDate.input</td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Expiry Date input field.</td>
+  </tr>
+  <tr>
+    <td>country.label</td>
+    <td>LabelStyle (see definition below)</td>
+    <td>The style of the Country field label.</td>
+  </tr>
+  <tr>
+    <td>country.input</td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Country input field.</td>
+  </tr>
+  <tr>
+    <td>terms.text</td>
+    <td>string<br>Default value: "I authorize {{scheme}} to monitor my payment card to identify transactions that qualify for a reward and for {{scheme}} to share such information with {{companyName}}, to enable my card linked offers and target offers that may be of interest to me."</td>
+    <td>The Terms of Use text.</td>
+  </tr>
+  <tr>
+    <td>terms.privacyUrl</td>
+    <td>string</td>
+    <td>The Privacy Policy URL.</td>
+  </tr>
+  <tr>
+    <td>terms.termsUrl</td>
+    <td>string</td>
+    <td>The Terms and Conditions URL.</td>
+  </tr>
+  <tr>
+    <td>terms.deleteInstructions</td>
+    <td>string<br>Default value: "going to your account settings"</td>
+    <td>Text to inform the user about how to opt out from the transaction monitoring. It is appended to the text "You may opt out of transaction monitoring on the payment card you entered at any time by".</td>
+  </tr>
+  <tr>
+    <td>terms.travelAndExpensesPlatform</td>
+    <td>string<br>Default value: "my T&amp;E Platform"</td>
+    <td>Text of the Travel and Expenses Platform.</td>
+  </tr>
+  <tr>
+    <td>terms.checkbox</td>
+    <td>style: CSS properties<br>checkedStyle: CSS properties</td>
+    <td>The styles of the terms checkbox.</td>
+  </tr>
+  <tr>
+    <td>terms.checkbox.checkColor</td>
+    <td>string</td>
+    <td>The border color of the terms checkbox.</td>
+  </tr>
+  <tr>
+    <td>submit</td>
+    <td>style: CSS properties<br>hoverStyle: CSS properties<br>loadingStyle: CSS properties<br>successStyle: CSS properties<br>defaultText: string<br>Default value: "Continue" | "Verify", depending on the step<br>loadingText: string<br>successText: string</td>
+    <td>Parameters to customize the CTA button on the screens of the card verification.</td>
+  </tr>
+  <tr>
+    <td>verificationIntro</td>
+    <td>buttonText: stringDefault value: "Continue"<br>title: string<br>Default value: "Get started"<br>description: string<br>Default value: "For identity verification purposes, we will send a microcharge (immediately refunded) to the card you connect. To connect and verify your card, follow these steps:"</td>
+    <td>Parameters to customize the first screen of the card verification.</td>
+  </tr>
+  <tr>
+    <td>verifyCard</td>
+    <td>title: string<br>Default value: "Verify your card"<br>description: string<br>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."<br>subDescription: string<br>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."<br>reconnectCardText: string<br>Default value: "Reconnect your card"<br>submit.style: CSS properties<br>submit.hoverStyle: CSS properties<br>submit.loadingStyle: CSS properties<br>submit.successStyle: CSS properties<br>submit.defaultText: string<br>Default value: Verify<br>submit.loadingText: string<br>submit.successText: string</td>
+    <td>Parameters to customize the second screen of the card verification.</td>
+  </tr>
+</tbody>
+</table>
+
+LabelStyles
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>label.hide</td>
+    <td>CSS properties</td>
+    <td>The default style of the input</td>
+  </tr>
+  <tr>
+    <td>label.style</td>
+    <td>CSS properties</td>
+    <td>The style of the input</td>
+  </tr>
+  <tr>
+    <td>label.errorStyle</td>
+    <td>CSS properties</td>
+    <td>The error style of the input</td>
+  </tr>
+  <tr>
+    <td>label.focusStyle</td>
+    <td>CSS properties</td>
+    <td>The focus style of the input</td>
+  </tr>
+  <tr>
+    <td>label.placeholderColor</td>
+    <td>string</td>
+    <td>The color of the input's placeholder</td>
+  </tr>
+</tbody>
+</table>
+
+InputStyles
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>input.style</td>
+    <td>CSS properties</td>
+    <td>The default style of the input</td>
+  </tr>
+  <tr>
+    <td>input.errorStyle</td>
+    <td>CSS properties</td>
+    <td>The error style of the input</td>
+  </tr>
+  <tr>
+    <td>input.focusStyle</td>
+    <td>CSS properties</td>
+    <td>The focus style of the input</td>
+  </tr>
+  <tr>
+    <td>input.placeholderColor</td>
+    <td>string</td>
+    <td>The color of the input's placeholder</td>
+  </tr>
+</tbody>
+</table>
+
+The definition of the `custom` parameter:
 
 ```javascript
 Fidel.openForm({

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -404,8 +404,8 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
       <code>successStyle</code>: CSS properties<br />
       <code>defaultText</code>: string<br />
       <em>Default value: "Continue" | "Verify", depending on the step</em><br />
-      <code>loadingText: string</code><br />
-      <code>successText: string</code>
+      <code>loadingText</code>: string<br />
+      <code>successText</code>: string
     </td>
     <td>Parameters to customize the CTA button on the screens of the card verification.</td>
   </tr>
@@ -591,7 +591,9 @@ Fidel.openForm({
         terms: {
             text: string,
             privacyUrl: string,
+            termsUrl: string,
             deleteInstructions: string,
+            travelAndExpensesPlatform: string,
             checkbox: {
                 style: CSSPropertiesObject,
                 checkedStyle: CSSPropertiesObject,
@@ -606,6 +608,26 @@ Fidel.openForm({
             defaultText: string,
             loadingText: string,
             successText: string,
+        },
+        verificationIntro: {
+            buttonText: string,
+            title: string,
+            description: string,
+        },
+        verifyCard: {
+            title: string,
+            description: string,
+            subDescription: string,
+            reconnectCardText: string,
+            submit: {
+              style: CSSPropertiesObject,
+              hoverStyle: CSSPropertiesObject,
+              loadingStyle: CSSPropertiesObject,
+              successStyle: CSSPropertiesObject,
+              defaultText: string,
+              loadingText: string,
+              successText: string,
+            },
         },
     }
 })

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -352,7 +352,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
     <td><code>terms.text</code></td>
     <td>
       string<br />
-      <em>Default value: "I authorize {{scheme}} to monitor my payment card to identify transactions that qualify for a reward and for {{scheme}} to share such information with {{companyName}}, to enable my card linked offers and target offers that may be of interest to me."</em>
+      <em>Default value: "I authorize &#123;&#123;scheme&#125;&#125; to monitor my payment card to identify transactions that qualify for a reward and for &#123;&#123;scheme&#125;&#125; to share such information with &#123;&#123;companyName&#125;&#125;, to enable my card linked offers and target offers that may be of interest to me."</em>
     </td>
     <td>The Terms of Use text.</td>
   </tr>
@@ -428,7 +428,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
       <code>title</code>: string<br />
       <em>Default value: "Verify your card"</em><br />
       <code>description</code>: string<br />
-      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."</em><br />
+      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact &#123;&#123;currency&#125;&#125; amount here within 48 hours."</em><br />
       <code>subDescription</code>: string<br />
       <em>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."</em><br />
       <code>reconnectCardText</code>: string<br />

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -391,12 +391,12 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
     <td>The styles of the terms checkbox.</td>
   </tr>
   <tr>
-    <td><code>terms.checkbox.checkColor</td>
+    <td><code>terms.checkbox.checkColor</code></td>
     <td>string</td>
     <td>The border color of the terms checkbox.</td>
   </tr>
   <tr>
-    <td><code>submit</td>
+    <td><code>submit</code></td>
     <td>
       <code>style</code>: CSS properties<br />
       <code>hoverStyle</code>: CSS properties<br />
@@ -410,7 +410,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
     <td>Parameters to customize the CTA button on the screens of the card verification.</td>
   </tr>
   <tr>
-    <td><code>verificationIntro</td>
+    <td><code>verificationIntro</code></td>
     <td>
       <code>buttonText</code>: string<br />
       <em>Default value: "Continue"</em><br />

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -136,7 +136,7 @@ const label = {
   <tr>
     <td><code>sdkKey</code><br /><strong>required</strong></td>
     <td>string</td>
-    <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with `pk_`.</td>
+    <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with "pk_".</td>
   </tr>
   <tr>
     <td><code>programId</code><br /><strong>required</strong></td>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -150,7 +150,7 @@ const label = {
   </tr>
   <tr>
     <td><code>programType</code></td>
-    <td>string<br><em>Possible values: 'select-transaction', 'transaction-select', 'transaction-stream'</em></td>
+    <td>string<br /><em>Possible values: 'select-transaction', 'transaction-select', 'transaction-stream'</em></td>
     <td>The type of the Fidel API Program to link the card to.</td>
   </tr>
   <tr>
@@ -165,12 +165,12 @@ const label = {
   </tr>
   <tr>
     <td><code>countries</code></td>
-    <td>array of strings<br><em>Possible values: 'GBR', 'IRL', 'USA', 'SWE'</em></td>
-    <td>If the array has only one value, that will be set as the country of issue for all collected cards and the country select box is removed from the UI.<br>If the array has multiple values, those will be the available options in the country select box.</td>
+    <td>array of strings<br /><em>Possible values: 'GBR', 'IRL', 'USA', 'SWE'</em></td>
+    <td>If the array has only one value, that will be set as the country of issue for all collected cards and the country select box is removed from the UI.<br />If the array has multiple values, those will be the available options in the country select box.</td>
   </tr>
   <tr>
     <td><code>language</code></td>
-    <td>string<br><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br>Default value: 'EN'</td>
+    <td>string<br /><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br />Default value: 'EN'</td>
     <td>The language to be displayed. It follows `window.navigator.language` language codes.</td>
   </tr>
   <tr>
@@ -180,12 +180,12 @@ const label = {
   </tr>
   <tr>
     <td><code>closeOnSuccess</code></td>
-    <td>boolean<br><em>Default value: true</em></td>
+    <td>boolean<br /><em>Default value: true</em></td>
     <td>Toggles the form's auto-close behavior on successful card linking.</td>
   </tr>
   <tr>
-    <td><code>schemes.mastercard</code><br><code>schemes.visa</code><br><code>schemes.amex</code></td>
-    <td>boolean<br><em>By default, all three are true.</em></td>
+    <td><code>schemes.mastercard</code><br /><code>schemes.visa</code><br /><code>schemes.amex</code></td>
+    <td>boolean<br /><em>By default, all three are true.</em></td>
     <td>Properties that toggle the availability of the Mastercard, Visa and Amex card schemes in the form.</td>
   </tr>
   <tr>
@@ -294,8 +294,8 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>close.location</code></td>
     <td>
-      string<br>
-      <em>Possible values: form | overlay | none</em><br>
+      string<br />
+      <em>Possible values: form | overlay | none</em><br />
       <em>Default value: overlay</em>
     </td>
     <td>The location of the close icon.</td>
@@ -308,7 +308,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>title.text</code></td>
     <td>
-      string<br>
+      string<br />
       <em>Default value: "Connect your card"</em>
     </td>
     <td>The text of the title at the top of the page.</td>
@@ -351,7 +351,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>terms.text</code></td>
     <td>
-      string<br>
+      string<br />
       <em>Default value: "I authorize {{scheme}} to monitor my payment card to identify transactions that qualify for a reward and for {{scheme}} to share such information with {{companyName}}, to enable my card linked offers and target offers that may be of interest to me."</em>
     </td>
     <td>The Terms of Use text.</td>
@@ -369,7 +369,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>terms.deleteInstructions</code></td>
     <td>
-      string<br>
+      string<br />
       <em>Default value: "going to your account settings"</em>
     </td>
     <td>Text to inform the user about how to opt out from the transaction monitoring. It is appended to the text "You may opt out of transaction monitoring on the payment card you entered at any time by".</td>
@@ -377,7 +377,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>terms.travelAndExpensesPlatform</code></td>
     <td>
-      string<br>
+      string<br />
       <em>Default value: "my T&amp;E Platform"</em>
     </td>
     <td>Text of the Travel and Expenses Platform.</td>
@@ -385,7 +385,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>terms.checkbox</code></td>
     <td>
-      <code>style</code>: CSS properties<br>
+      <code>style</code>: CSS properties<br />
       <code>checkedStyle</code>: CSS properties
     </td>
     <td>The styles of the terms checkbox.</td>
@@ -398,13 +398,13 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>submit</td>
     <td>
-      <code>style</code>: CSS properties<br>
-      <code>hoverStyle</code>: CSS properties<br>
-      <code>loadingStyle</code>: CSS properties<br>
-      <code>successStyle</code>: CSS properties<br>
-      <code>defaultText</code>: string<br>
-      <em>Default value: "Continue" | "Verify", depending on the step</em><br>
-      <code>loadingText: string</code><br>
+      <code>style</code>: CSS properties<br />
+      <code>hoverStyle</code>: CSS properties<br />
+      <code>loadingStyle</code>: CSS properties<br />
+      <code>successStyle</code>: CSS properties<br />
+      <code>defaultText</code>: string<br />
+      <em>Default value: "Continue" | "Verify", depending on the step</em><br />
+      <code>loadingText: string</code><br />
       <code>successText: string</code>
     </td>
     <td>Parameters to customize the CTA button on the screens of the card verification.</td>
@@ -412,11 +412,11 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td><code>verificationIntro</td>
     <td>
-      <code>buttonText</code>: string<br>
-      <em>Default value: "Continue"</em><br>
-      <code>title</code>: string<br>
-      <em>Default value: "Get started"</em><br>
-      <code>description</code>: string<br>
+      <code>buttonText</code>: string<br />
+      <em>Default value: "Continue"</em><br />
+      <code>title</code>: string<br />
+      <em>Default value: "Get started"</em><br />
+      <code>description</code>: string<br />
       <em>Default value: "For identity verification purposes, we will send a microcharge (immediately refunded) to the card you connect. 
           To connect and verify your card, follow these steps:"</em>
     </td>
@@ -425,21 +425,21 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   <tr>
     <td>verifyCard</td>
     <td>
-      <code>title</code>: string<br>
-      <em>Default value: "Verify your card"</em><br>
-      <code>description</code>: string<br>
-      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."</em><br>
-      <code>subDescription</code>: string<br>
-      <em>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."</em><br>
-      <code>reconnectCardText</code>: string<br>
-      <em>Default value: "Reconnect your card"</em><br>
-      <code>submit.style</code>: CSS properties<br>
-      <code>submit.hoverStyle</code>: CSS properties<br>
-      <code>submit.loadingStyle</code>: CSS properties<br>
-      <code>submit.successStyle</code>: CSS properties<br>
-      <code>submit.defaultText</code>: string<br>
-      <em>Default value: Verify</em><br>
-      <code>submit.loadingText</code>: string<br>
+      <code>title</code>: string<br />
+      <em>Default value: "Verify your card"</em><br />
+      <code>description</code>: string<br />
+      <em>Default value: "Check your card statement for the microcharge amount from "Card Verification", and enter the exact {{currency}} amount here within 48 hours."</em><br />
+      <code>subDescription</code>: string<br />
+      <em>Default value: "All microcharges are used for identity verification purposes only, and are immediately refunded."</em><br />
+      <code>reconnectCardText</code>: string<br />
+      <em>Default value: "Reconnect your card"</em><br />
+      <code>submit.style</code>: CSS properties<br />
+      <code>submit.hoverStyle</code>: CSS properties<br />
+      <code>submit.loadingStyle</code>: CSS properties<br />
+      <code>submit.successStyle</code>: CSS properties<br />
+      <code>submit.defaultText</code>: string<br />
+      <em>Default value: Verify</em><br />
+      <code>submit.loadingText</code>: string<br />
       <code>submit.successText</code>: string</td>
     <td>Parameters to customize the second screen of the card verification.</td>
   </tr>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -262,7 +262,7 @@ document.getElementById("open-form").addEventListener("click", function() {
 
 The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of parameters, all of which are optional.
 
-<table>
+<table border=1 cellpadding=3 cellspacing=0 style="border: 1pt solid #000000; border-Collapse: collapse" >
 <thead>
   <tr>
     <th>Parameter</th>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -320,7 +320,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   </tr>
   <tr>
     <td><code>cardNumber.label</code></td>
-    <td>LabelStyle (see definition below)</td>
+    <td>LabelStyles (see definition below)</td>
     <td>The style of the Card Number label.</td>
   </tr>
   <tr>
@@ -330,7 +330,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   </tr>
   <tr>
     <td><code>expiryDate.label</code></td>
-    <td>LabelStyle (see definition below)</td>
+    <td>LabelStyles (see definition below)</td>
     <td>The style of the Expiry Date label.</td>
   </tr>
   <tr>
@@ -340,7 +340,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
   </tr>
   <tr>
     <td><code>country.label</code></td>
-    <td>LabelStyle (see definition below)</td>
+    <td>LabelStyles (see definition below)</td>
     <td>The style of the Country field label.</td>
   </tr>
   <tr>
@@ -446,7 +446,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
 </tbody>
 </table>
 
-LabelStyles
+The **LabelStyles** type includes the following parameters:
 
 <table>
 <thead>
@@ -485,7 +485,7 @@ LabelStyles
 </tbody>
 </table>
 
-InputStyles
+The **InputStyles** type includes the following parameters:
 
 <table>
 <thead>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -129,17 +129,17 @@ const label = {
 </thead>
 <tbody>
   <tr>
-    <td><code>companyName</code><br /><strong>required</strong></td>
+    <td><code>companyName</code> <strong>required</strong></td>
     <td>string</td>
     <td>The name of the company using card linking.</td>
   </tr>
   <tr>
-    <td><code>sdkKey</code><br /><strong>required</strong></td>
+    <td><code>sdkKey</code> <strong>required</strong></td>
     <td>string</td>
     <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with "pk_".</td>
   </tr>
   <tr>
-    <td><code>programId</code><br /><strong>required</strong></td>
+    <td><code>programId</code> <strong>required</strong></td>
     <td>string</td>
     <td>The id of the Fidel API Program to link the card to.</td>
   </tr>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -262,7 +262,7 @@ document.getElementById("open-form").addEventListener("click", function() {
 
 The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of parameters, all of which are optional.
 
-<table border=1 cellpadding=3 cellspacing=0 style="border: 1pt solid #000000; border-Collapse: collapse" >
+<table>
 <thead>
   <tr>
     <th>Parameter</th>

--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -423,7 +423,7 @@ The `custom` property allows for customizing most of the Fidel Web SDK UI. It su
     <td>Parameters to customize the first screen of the card verification.</td>
   </tr>
   <tr>
-    <td>verifyCard</td>
+    <td><code>verifyCard</code></td>
     <td>
       <code>title</code>: string<br />
       <em>Default value: "Verify your card"</em><br />


### PR DESCRIPTION
Jira issue: [JO-246](https://fidel.atlassian.net/browse/JO-246)

**Changelog**
In the "Fidel Web SDK Parameters" section:
* Adding the missing parameters ´programName´, ´language´, ´container´.
* Changing from definition list to a table, to add more structure to the content.

In the "Customizing the Web SDK" section:
* Adding the missing table with all the custom sub-parameters.
* Adding a table for LabelStyles and InputStyles parameters, as suggested by Jorge.
* Updating the definition of the ´custom´ parameter under the tables