### PR TITLE
[JO-246] Add full list of parameters to web sdk 3 documentation [PATCH]

### DIFF
--- a/web-sdk/v3.md
+++ b/web-sdk/v3.md
@@ -119,72 +119,81 @@ const label = {
 
 #### Fidel Web SDK Parameters
 
-<dl>
-    <div>
-        <dt>
-            <span><code>companyName</code></span>
-		<strong>required</strong>
-        </dt>
-        <dd>the name of the company using card-linking</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>sdkKey</code></span>
-            <strong>required</strong>
-        </dt>
-        <dd>a valid SDK Key. You can find yours in the <a href="https://dashboard.fidel.uk/account/plan">Fidel Dashboard</a>. It starts with `pk_`.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>programId</code></span>
-            <strong>required</strong>
-        </dt>
-        <dd>the id of the Fidel Program to link the card to.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>callback</code></span>
-        </dt>
-        <dd>callback function to be called when the form is submitted</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>countries</code></span>
-            <em>Array with possible values: GBR, IRL, USA, SWE</em>
-        </dt>
-        <dd>when the array has only one entry, that is set as the country of issue for all Cards collected and the country select box is removed from the UI. If the array has multiple entries, those are the only ones available in the country select box.</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>metadata</code></span>
-        </dt>
-        <dd>name of the global metadata object</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>closeOnSuccess</code></span>
-            <em>default: true</em>
-        </dt>
-        <dd>toggles the web form auto-close behaviour on successful card linking</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>schemes</code></span>
-            <em>object with boolean properties for mastercard, visa and amex. By default, all three are true.</em>
-        </dt>
-        <dd>toggles the availability of the Mastercard, Visa and Amex card schemes in the form</dd>
-    </div>
-    <div>
-        <dt>
-            <span><code>custom</code></span>
-        </dt>
-        <dd>object that allows you to customize the UI for the Web SDK. You can find the structure for it in the customization section below.</dd>
-    </div>
-</dl>
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>companyName</code> <strong>required</strong></td>
+    <td>string</td>
+    <td>The name of the company using card linking.</td>
+  </tr>
+  <tr>
+    <td><code>sdkKey</code> <strong>required</strong></td>
+    <td>string</td>
+    <td>A valid SDK Key. You can find yours on the <a href="https://dashboard.fidel.uk/account/plan">Dashboard</a>. It starts with "pk_".</td>
+  </tr>
+  <tr>
+    <td><code>programId</code> <strong>required</strong></td>
+    <td>string</td>
+    <td>The id of the Fidel API Program to link the card to.</td>
+  </tr>
+  <tr>
+    <td><code>programName</code></td>
+    <td>string</td>
+    <td>The name of the Fidel API Program to link the card to.</td>
+  </tr>
+  <tr>
+    <td><code>callback</code></td>
+    <td>function</td>
+    <td>Function to be called when the form is submitted.</td>
+  </tr>
+  <tr>
+    <td><code>container</code></td>
+    <td>HTML element</td>
+    <td>A wrapper element that you can wrap around the iframe.</td>
+  </tr>
+  <tr>
+    <td><code>countries</code></td>
+    <td>array of strings<br /><em>Possible values: 'GBR', 'IRL', 'USA', 'SWE'</em></td>
+    <td>If the array has only one value, that will be set as the country of issue for all collected cards and the country select box is removed from the UI.<br />If the array has multiple values, those will be the available options in the country select box.</td>
+  </tr>
+  <tr>
+    <td><code>language</code></td>
+    <td>string<br /><em>Possible values: 'EN', 'EN-BG', 'FR', 'JA', 'SV'</em><br /><em>Default value: 'EN'</em></td>
+    <td>The language to be displayed. It follows `window.navigator.language` language codes.</td>
+  </tr>
+  <tr>
+    <td><code>metadata</code></td>
+    <td>Record&lt;string, any&gt;</td>
+    <td>The global metadata object. See more details in the next sections.</td>
+  </tr>
+  <tr>
+    <td><code>closeOnSuccess</code></td>
+    <td>boolean<br /><em>Default value: true</em></td>
+    <td>Toggles the form's auto-close behavior on successful card linking.</td>
+  </tr>
+  <tr>
+    <td><code>schemes.mastercard</code><br /><code>schemes.visa</code><br /><code>schemes.amex</code></td>
+    <td>boolean<br /><em>By default, all three are true.</em></td>
+    <td>Properties that toggle the availability of the Mastercard, Visa and Amex card schemes in the form.</td>
+  </tr>
+  <tr>
+    <td><code>custom</code></td>
+    <td>object</td>
+    <td>Object that allows you to customize the UI for the Web SDK. You can find the structure for it in the customization section below.</td>
+  </tr>
+</tbody>
+</table>
 
 #### Fidel Web SDK Global Object
 
-After adding the Web SDK script on your website, a global variable `Fidel` is created with two methods that you can use to open and close the web form manually, `Fidel.openForm()` and `Fidel.closeForm()`. 
+After adding the Web SDK script on your website, a global variable `Fidel` is created with two methods that you can use to open and close the web form manually, `Fidel.openForm()` and `Fidel.closeForm()`.
 
 To open the iframe overlay form with a button, you could use this example:
 
@@ -246,7 +255,224 @@ document.getElementById("open-form").addEventListener("click", function() {
 
 ## Customizing the Web SDK
 
-The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of paramets, all of which are optional.
+The `custom` property allows for customizing most of the Fidel Web SDK UI. It supports the same CSS properties as the [HTML DOM Style Object](https://www.w3schools.com/jsref/dom_obj_style.asp). Here is a complete list of parameters, all of which are optional.
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>logo.url</code></td>
+    <td>string</td>
+    <td>The URL of the logo on the iframe.</td>
+  </tr>
+  <tr>
+    <td><code>logo.style</code></td>
+    <td>CSS properties</td>
+    <td>The style of the logo on the iframe.</td>
+  </tr>
+  <tr>
+    <td><code>form.style</code></td>
+    <td>CSS properties</td>
+    <td>The style of the form element of the iframe.</td>
+  </tr>
+  <tr>
+    <td><code>overlay.style</code></td>
+    <td>CSS properties</td>
+    <td>The style of the overlay element of the iframe.</td>
+  </tr>
+  <tr>
+    <td><code>close.location</code></td>
+    <td>
+      string<br />
+      <em>Possible values: form | overlay | none</em><br />
+      <em>Default value: overlay</em>
+    </td>
+    <td>The location of the close icon.</td>
+  </tr>
+  <tr>
+    <td><code>close.color</code></td>
+    <td>string</td>
+    <td>The color of the close icon.</td>
+  </tr>
+  <tr>
+    <td><code>title.text</code></td>
+    <td>
+      string<br />
+      <em>Default value: "Connect your card"</em>
+    </td>
+    <td>The text of the title at the top of the page.</td>
+  </tr>
+  <tr>
+    <td><code>title.style</code></td>
+    <td>CSS properties</td>
+    <td>The style of the title at the top of the page.</td>
+  </tr>
+  <tr>
+    <td><code>cardNumber.label</code></td>
+    <td>LabelStyles (see definition below)</td>
+    <td>The style of the Card Number label.</td>
+  </tr>
+  <tr>
+    <td><code>cardNumber.input</code></td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Card Number input field.</td>
+  </tr>
+  <tr>
+    <td><code>expiryDate.label</code></td>
+    <td>LabelStyles (see definition below)</td>
+    <td>The style of the Expiry Date label.</td>
+  </tr>
+  <tr>
+    <td><code>expiryDate.input</code></td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Expiry Date input field.</td>
+  </tr>
+  <tr>
+    <td><code>country.label</code></td>
+    <td>LabelStyles (see definition below)</td>
+    <td>The style of the Country field label.</td>
+  </tr>
+  <tr>
+    <td><code>country.input</code></td>
+    <td>InputStyle (see definition below)</td>
+    <td>The style of the Country input field.</td>
+  </tr>
+  <tr>
+    <td><code>terms.text</code></td>
+    <td>
+      string<br />
+      <em>Default value: "I authorize &#123;&#123;scheme&#125;&#125; to monitor my payment card to identify transactions that qualify for a reward and for &#123;&#123;scheme&#125;&#125; to share such information with &#123;&#123;companyName&#125;&#125;, to enable my card linked offers and target offers that may be of interest to me."</em>
+    </td>
+    <td>The Terms of Use text.</td>
+  </tr>
+  <tr>
+    <td><code>terms.privacyUrl</code></td>
+    <td>string</td>
+    <td>The Privacy Policy URL.</td>
+  </tr>
+  <tr>
+    <td><code>terms.termsUrl</code></td>
+    <td>string</td>
+    <td>The Terms and Conditions URL.</td>
+  </tr>
+  <tr>
+    <td><code>terms.deleteInstructions</code></td>
+    <td>
+      string<br />
+      <em>Default value: "going to your account settings"</em>
+    </td>
+    <td>Text to inform the user about how to opt out from the transaction monitoring. It is appended to the text "You may opt out of transaction monitoring on the payment card you entered at any time by".</td>
+  </tr>
+  <tr>
+    <td><code>terms.checkbox</code></td>
+    <td>
+      <code>style</code>: CSS properties<br />
+      <code>checkedStyle</code>: CSS properties
+    </td>
+    <td>The styles of the terms checkbox.</td>
+  </tr>
+  <tr>
+    <td><code>terms.checkbox.checkColor</code></td>
+    <td>string</td>
+    <td>The border color of the terms checkbox.</td>
+  </tr>
+  <tr>
+    <td><code>submit</code></td>
+    <td>
+      <code>style</code>: CSS properties<br />
+      <code>hoverStyle</code>: CSS properties<br />
+      <code>loadingStyle</code>: CSS properties<br />
+      <code>successStyle</code>: CSS properties<br />
+      <code>defaultText</code>: string<br />
+      <em>Default value: "Continue" | "Verify", depending on the step</em><br />
+      <code>loadingText</code>: string<br />
+      <code>successText</code>: string
+    </td>
+    <td>Parameters to customize the CTA button on the screens of the card verification.</td>
+  </tr>
+</tbody>
+</table>
+
+The **LabelStyles** type includes the following parameters:
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>label.hide</code></td>
+    <td>CSS properties</td>
+    <td>The default style of the input</td>
+  </tr>
+  <tr>
+    <td><code>label.style</code></td>
+    <td>CSS properties</td>
+    <td>The style of the input</td>
+  </tr>
+  <tr>
+    <td><code>label.errorStyle</code></td>
+    <td>CSS properties</td>
+    <td>The error style of the input</td>
+  </tr>
+  <tr>
+    <td><code>label.focusStyle</code></td>
+    <td>CSS properties</td>
+    <td>The focus style of the input</td>
+  </tr>
+  <tr>
+    <td><code>label.placeholderColor</code></td>
+    <td>string</td>
+    <td>The color of the input's placeholder</td>
+  </tr>
+</tbody>
+</table>
+
+The **InputStyles** type includes the following parameters:
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>input.style</code></td>
+    <td>CSS properties</td>
+    <td>The default style of the input</td>
+  </tr>
+  <tr>
+    <td><code>input.errorStyle</code></td>
+    <td>CSS properties</td>
+    <td>The error style of the input</td>
+  </tr>
+  <tr>
+    <td><code>input.focusStyle</code></td>
+    <td>CSS properties</td>
+    <td>The focus style of the input</td>
+  </tr>
+  <tr>
+    <td><code>input.placeholderColor</code></td>
+    <td>string</td>
+    <td>The color of the input's placeholder</td>
+  </tr>
+</tbody>
+</table>
+
+The definition of the `custom` parameter:
 
 ```javascript
 Fidel.openForm({
@@ -318,6 +544,7 @@ Fidel.openForm({
         terms: {
             text: string,
             privacyUrl: string,
+            termsUrl: string,
             deleteInstructions: string,
             checkbox: {
                 style: CSSPropertiesObject,


### PR DESCRIPTION
Jira issue: [JO-246](https://fidel.atlassian.net/browse/JO-246)

**Changelog**
In the "Fidel Web SDK Parameters" section:
* Adding the missing parameters ´programName´, ´language´, ´container´.
* Changing from definition list to a table, to add more structure to the content.

In the "Customizing the Web SDK" section:
* Adding the missing table with all the custom sub-parameters.
* Adding a table for LabelStyles and InputStyles parameters, as suggested by Jorge.
* Updating the definition of the ´custom´ parameter under the tables

[![Netlify Status](https://api.netlify.com/api/v1/badges/ed4dd32a-4aed-4dc8-8404-ec3864936bd5/deploy-status)](https://app.netlify.com/sites/fidel-website/deploys)
