### PR TITLE
Core/change deploy preview link [PATCH]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/ed4dd32a-4aed-4dc8-8404-ec3864936bd5/deploy-status)](https://app.netlify.com/sites/fidel-website/deploys)
+[Deploy preview](https://master.d30jf5gj5vctl9.amplifyapp.com/)


### PR DESCRIPTION
With the change to move the PR Preview from Netlify to Amplify, the link that we show on the PRs here needs to be changed as well.
