### PR TITLE
[DOC-38] Removing links to the Community Forum [PATCH]

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,8 +45,6 @@ You can see an example implementation for integrating the Fidel APIs and Web SDK
 
 Check out the [API Reference](https://reference.fidel.uk) to see all available requests, code examples and response payloads.
 
-Join our [Developer Community](https://community.fidel.uk/) for API discussions, documentation, frequently asked questions, roadmap and new features. We’re always happy to help and answer any questions.
-
 ## Card Linking
 The [iOS](/mobile-sdks/#ios), [Android](/mobile-sdks/#android) and [Web](/web-sdk/v3) SDKs provide you a secure UI to collect your user’s card details securely on the web or mobile.
 

--- a/locations.md
+++ b/locations.md
@@ -33,7 +33,6 @@ The information required for each location is the Brand (with approved consent),
     If you need to onboard payment facilitators (Square, iZettle, SumUp, etc.), they may be using shared merchant IDs that have an impact on how transactions are monitored. Reach out to Fidel if you work with merchants that use payment facilitators.
 </div>
 
-You can read more about [shared MIDs in this article](https://community.fidel.uk/t/what-is-a-shared-merchant-id-mid/41).
 Once you have added your locations to Fidel, we can begin the process of Location Sync ⚡️. This step requires submitting all of the locations for onboarding with Visa, Mastercard and American Express, so that we may track credit/debit card transactions at each location. During this process, you can monitor and keep track of the status of each location.
 
 ## Location Sync

--- a/mobile-sdks.md
+++ b/mobile-sdks.md
@@ -68,7 +68,7 @@ Fidel.present(self, onCardLinkedCallback: { (card: LinkResult) in
 })
 ```
 
-If you run into any issues, [check issues on Github](https://github.com/FidelLimited/fidel-ios).
+If you run into a problem, check the [issues section of the SDK repository](https://github.com/FidelLimited/fidel-ios/issues).
 
 ## Android
 
@@ -154,7 +154,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
-If you run into any issues, [check issues on Github](https://github.com/FidelLimited/fidel-android).
+If you run into a problem, check the [issues section of the SDK repository](https://github.com/FidelLimited/fidel-android/issues).
 
 ## React Native
 
@@ -469,7 +469,7 @@ Amex: `3400000000003**` or `3700000000003**` (the last 2 numbers can be anything
 
 ### Feedback
 
-The React Native SDK is in active development, we welcome your feedback!
+The React Native SDK is in active development, you are welcome to leave feedback!
 
 [GitHub Issues](https://github.com/fidellimited/rn-sdk/issues) — For SDK issues and feedback.
 

--- a/mobile-sdks.md
+++ b/mobile-sdks.md
@@ -68,7 +68,7 @@ Fidel.present(self, onCardLinkedCallback: { (card: LinkResult) in
 })
 ```
 
-If you run into any issues, [let us know in the Developer Community](https://community.fidel.uk/c/Issues-or-Questions-on-our-mobile-SDKs/) or [check issues on Github](https://github.com/FidelLimited/fidel-ios).
+If you run into any issues, [check issues on Github](https://github.com/FidelLimited/fidel-ios).
 
 ## Android
 
@@ -154,7 +154,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
-If you run into any issues, [let us know in the Developer Community](https://community.fidel.uk/c/Issues-or-Questions-on-our-mobile-SDKs/) or [check issues on Github](https://github.com/FidelLimited/fidel-android).
+If you run into any issues, [check issues on Github](https://github.com/FidelLimited/fidel-android).
 
 ## React Native
 
@@ -471,7 +471,6 @@ Amex: `3400000000003**` or `3700000000003**` (the last 2 numbers can be anything
 
 The React Native SDK is in active development, we welcome your feedback!
 
-[Developers Community](https://community.fidel.uk/) — for support and troubleshooting at any phase of integration.  
 [GitHub Issues](https://github.com/fidellimited/rn-sdk/issues) — For SDK issues and feedback.
 
 ## Banner Images

--- a/webhooks.md
+++ b/webhooks.md
@@ -2,7 +2,7 @@
 
 Fidel API uses [webhooks](https://en.wikipedia.org/wiki/Webhook) to notify your application when relevant events happen in your account across multiple resources, namely with event types such as `brand.consent`, `card.failed`, `card.linked`, `location.status`, `program.status`, `transaction.auth.qualified`, `transaction.auth`, `transaction.clearing.qualified`, `transaction.clearing`, `transaction.refund.qualified`, and `transaction.refund`.
 
-Fidel API will notify your registered webhook URLs as the event happens, via a HTTP POST request with a signature header for verification, which needs to be received and acknowledged in a timely manner. The HTTP request contains the event object as payload. 
+Fidel API will notify your registered webhook URLs as the event happens, via a HTTP POST request with a signature header for verification, which needs to be received and acknowledged in a timely manner. The HTTP request contains the event object as payload.
 
 For example, when a customer makes a payment with a linked Mastercard card, on a participating location, a `transaction.auth` event is sent in real-time to the specified webhook URL, with a payload that contains the Transaction object.
 
@@ -10,7 +10,7 @@ For example, when a customer makes a payment with a linked Mastercard card, on a
 
 There are two ways you can manage your webhooks, i.e., view, create, update, delete, with the Fidel API. You can create them in the [Fidel Dashboard, under the "Webhooks" page](https://dashboard.fidel.uk/webhooks) or make HTTP requests using the [Webhooks API](https://reference.fidel.uk/reference/create-webhook-brand).
 
-As requirements for creation, Fidel API only accepts HTTPS URLs for webhook endpoints, thus your server must support HTTPS and have a valid certificate. 
+As requirements for creation, Fidel API only accepts HTTPS URLs for webhook endpoints, thus your server must support HTTPS and have a valid certificate.
 
 Fidel API sends the data via HTTP POST in JSON format. It will send test events if your Dashboard is in test mode or if you are using test API keys when registering the webhook URLs. To receive live events, flip your switch on the Dashboard to go live, or create the webhooks using a live API key.
 
@@ -138,10 +138,6 @@ A maximum of 5 custom headers per webhook can be defined, and they need to follo
   "X-Fidel-Timestamp"
 ]
 ```
-
-## Events
-
-We are working to extend the list of events. If you require any specific event that is not available yet, please reach out on our [community forum](https://community.fidel.uk/) or email us at [devrel@fidel.uk](mailto:devrel@fidel.uk).
 
 ### Brand
 
@@ -472,7 +468,7 @@ fileName:transaction.refund
 }
 ```
 
-There are three additional transaction webhook events: `transaction.auth.qualified`, `transaction.clearing.qualified` and `transaction.refund.qualified`. They are triggered when an `auth`, `clearing` or a `refund` transaction is qualified for an Offer. 
+There are three additional transaction webhook events: `transaction.auth.qualified`, `transaction.clearing.qualified` and `transaction.refund.qualified`. They are triggered when an `auth`, `clearing` or a `refund` transaction is qualified for an Offer.
 
 `transaction.auth.qualified` and `transaction.clearing.qualified` events are triggered only if transactions they are inside of the offer's period and pass the set of rules defined in the offer. `transaction.refund.qualified` events might be emitted even when the offer has expired due to the complex matching logic of the refund to the original transaction.
 


### PR DESCRIPTION
Ticket: https://fidelapi.atlassian.net/browse/DOC-38
Description: Removing the links to the Community Forum, as it is discontinued now.

#### Steps to test

- Go to the website project.
- Run `env DOCS_BRANCH=this-pr-branch yarn docs` to download the docs files from this PR.
- Run `yarn start` and go to `/docs` to check the changes.
