### PR TITLE
[CLET-174] Remove all the references to card scanning 

### DIFF
--- a/select/sdks/android/reference.md
+++ b/select/sdks/android/reference.md
@@ -141,12 +141,6 @@ You need to provide the image for all screen densities.
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
 
-#### autoScan: Boolean
-
-Default value: `false`.
-
-When set to `true`, the enrollment flow will automatically start a card camera scanning UI. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
-
 #### programName: String
 
 Default value: `"our"`

--- a/select/sdks/ios/reference.md
+++ b/select/sdks/ios/reference.md
@@ -142,11 +142,6 @@ You need to provide the image for all screen densities (x1, x2 and x3).
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
 
-#### autoScan: Bool
-
-Default value: `false`.
-
-When set to `true`, the enrollment flow will automatically start a card camera scanning UI. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
 
 #### programName: String
 

--- a/select/sdks/react-native/reference.md
+++ b/select/sdks/react-native/reference.md
@@ -58,7 +58,6 @@ Fidel.setOptions({
   allowedCountries: countries,
   defaultSelectedCountry: Fidel.Country.unitedStates,
   supportedCardSchemes: cardSchemes,
-  autoScan: false,
   metaData: { id: "your-metadata-id", customKey: "customValue" },
   companyName: "My RN Company",
   deleteInstructions: "Your custom delete instructions!",
@@ -179,14 +178,6 @@ If a device that opens the SDK has 475dp in width, the aspect ratio of your bann
 You need to provide the image for all screen densities (x1, x2 and x3).
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
-
-#### autoScan
-
-Expected type: `boolean`
-
-Default value: `false`.
-
-When set to `true`, the enrollment flow will automatically start a card camera scanning UI. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
 
 #### programName
 

--- a/stream/sdks/android/reference.md
+++ b/stream/sdks/android/reference.md
@@ -159,20 +159,6 @@ You need to provide the image for all screen densities.
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
 
-#### enableCardScanner: Boolean
-
-Default value: `false`.
-
-When set to `true`, enables card camera scanning feature in the card details screen. Cardholders will be able to click a button to scan their card using their device's camera. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled. When `false`, the `shouldAutoScanCard` property will be ignored.
-
-> Note: The card scanning feature does not work well with all types of cards.
-
-#### shouldAutoScanCard: Boolean
-
-Default value: `false`.
-
-When set to `true` and when `enableCardScanner` is set to `true`, this will automatically starts card camera scanning UI, in the card details screen. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
-
 ### Properties that are not in use for Transaction Stream programs
 
 The following properties are only useful when enrolling cards in a Select Transactions program.

--- a/stream/sdks/ios/reference.md
+++ b/stream/sdks/ios/reference.md
@@ -160,19 +160,6 @@ You need to provide the image for all screen densities (x1, x2 and x3).
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
 
-#### enableCardScanner: Bool
-
-Default value: `false`.
-
-When set to `true`, enables card camera scanning feature in the card details screen. Cardholders will be able to click a button to scan their card using their iPhone camera. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled. When `false`, the `shouldAutoScanCard` property will be ignored.
-
-> Note: The card scanning feature does not work well with all types of cards.
-
-#### shouldAutoScanCard: Bool
-
-Default value: `false`.
-
-When set to `true` and when `enableCardScanner` is set to `true`, this will automatically starts card camera scanning UI, in the card details screen. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
 
 ### Properties that are not in use for Transaction Stream programs
 

--- a/stream/sdks/react-native/reference.md
+++ b/stream/sdks/react-native/reference.md
@@ -42,8 +42,6 @@ export default class App extends React.Component {
         bannerImage: resolvedImage,
         allowedCountries: countries,
         supportedCardSchemes: [Fidel.CardScheme.visa],
-        shouldAutoScanCard: false,
-        enableCardScanner: false,
         metaData: { id: 'your-metadata-id', userId: 1234 },
         thirdPartyVerificationChoice: false //set to true if you need to enable third party verification
       },
@@ -332,23 +330,6 @@ You need to provide the image for all screen densities (x1, x2 and x3).
 
 Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
 
-#### options.enableCardScanner
-
-Expected type: `boolean`
-
-Default value: `false`
-
-When set to `true`, enables card camera scanning feature in the card details screen. Cardholders will be able to click a button to scan their card using their iPhone camera. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled. When `false`, the [`shouldAutoScanCard`](#shouldautoscancard) property will be ignored.
-
-> Note: The card scanning feature does not work well with all types of cards.
-
-#### options.shouldAutoScanCard
-
-Expected type: `boolean`
-
-Default value: `false`
-
-When set to `true` and when [`enableCardScanner`](#enablecardscanne) is set to `true`, this will automatically starts card camera scanning UI, in the card details screen. After card scanning is finalized, the user will go to our normal card enrollment UI with the card details prefilled.
 
 ### Properties that are not in use for Transaction Stream programs
 


### PR DESCRIPTION
Remove all references to card scanning (both stream and select) since it has now been deprecated for all mobile SDKs.

#### Steps to test

- Go to the website project.
- Run `env DOCS_BRANCH=this-pr-branch yarn docs` to download the docs files from this PR.
- Run `yarn start` and go to `/docs` to check the changes.
