### PR TITLE
Add v2 Select Transactions docs for the Android SDK.

### DIFF
--- a/select/sdks/android/guide-v1.md
+++ b/select/sdks/android/guide-v1.md
@@ -1,8 +1,10 @@
-# A guide for card enrollment with the iOS SDK
+# A guide for card enrollment with the Android SDK <a style="border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/android/guide-v1">v1</a> <a style="margin-right: auto; color: #111;" class="improve-docs" href="/select/sdks/android/guide-v2">v2</a>
 
 Please take the following steps to integrate and configure the SDK for your Loyalty use case application.
 
-> Note: If an example project helps with your SDK integration & configuration, please check our [GitHub repository](https://github.com/FidelLimited/fidel-ios/).
+> Note: All code examples in this guide and other Android SDK pages will be written in Kotlin, but our SDK works well in Java projects as well.
+
+> Note: If an example project helps with your SDK integration & configuration, please check our [GitHub repository](https://github.com/FidelLimited/fidel-android/).
 
 ### 1. Set up your Fidel API account & your Transaction Select program
 
@@ -10,105 +12,76 @@ To get started, you'll need a Fidel API account. [Sign up](https://dashboard.fid
 
 If you didn't create a program for your application yet, please create a Transaction Select program from your Fidel API dashboard (or via the API).
 
-### 2. Integrate the iOS SDK into your project
+### 2. Integrate the Android SDK into your project
 
-#### Using Cocoapods
-> Info: If you prefer *not* to use Cocoapods, please check our instructions about integrating the SDK manually below.
+#### From the remote repository (JitPack)
 
-- Install [CocoaPods](https://cocoapods.org/), if you haven't already.
+- Add the JitPack repository to your Android project.
+    - If your repositories are declared in your project's `build.gradle` file, add the JitPack repository:
 
-- If your iOS project does not use Cocoapods (it does not contain a `Podfile` file), run the following command to initialize it:
+    ```groovy
+    fileName:build.gradle
+    allprojects {
+        repositories {
+            ...
+            maven { url 'https://jitpack.io' }
+        }
+    }
+    ```
 
-```
-pod init
-```
+    - If your project centrally declares repositories, add the JitPack repository in your `settings.gradle` file:
 
-- Add the following line in your `Podfile`, representing the Fidel API iOS SDK dependency that you're adding to your project:
+    ```groovy
+    fileName:settings.gradle
+    dependencyResolutionManagement {
+        repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+        repositories {
+            ...
+            maven { url 'https://jitpack.io' }
+        }
+    }
+    ```
 
-```ruby
-pod 'Fidel'
-```
+- Check what's the latest version of the Fidel API Android SDK in our Releases page.
 
-Your `Podfile` should have a structure similar to the following:
-```ruby
-fileName:Podfile
-platform :ios, '14'
+- Add the latest version of our SDK as a dependency in your app's module `build.gradle` file:
 
-target 'YouriOSTarget' do
-    use_frameworks!
-
-    pod 'Fidel'
-    # ... other pods, if you're using Cocoapods already
-end
-```
-
-- Run the following command to install the Fidel API iOS SDK dependency:
-
-```
-pod install
-```
-
-- To start working with the Fidel API iOS SDK in your project, from now on, please don't forget to open your project's `.xcworkspace` file, not the `.xcodeproj` file. The `.xcworkspace` file is created by Cocoapods, when running the previous command.
-
-- In the future, to update to the latest iOS SDK version, please run:
-
-```
-pod update Fidel
+```groovy
+fileName:app/build.gradle
+implementation 'com.github.FidelLimited:android-sdk:1.7.5'
 ```
 
-> Note: For information about all the Fidel API iOS SDK versions that are used by loyalty use case applications, please check our Releases page.
+- In the future, to update to the latest Android SDK version, please update the version in your `app/build.gradle` file and `Sync` your Android project again.
 
-#### Manual framework integration
-
-> Info: If you prefer to use Cocoapods, please check our instructions about [integrating the SDK using Cocoapods](#using-cocoapods).
-
-- Download the latest version of the `Fidel.xcframework` artefact from the `master` branch of our [GitHub repo](https://github.com/FidelLimited/fidel-ios).
-
-- Open your iOS app project in Xcode.
-
-- Right click on your project and then on the `Add Files to "YourProjectName"...` button.
-
-- Select the `Fidel.xcframework` artefact. Make sure to select the `Copy items if needed` option.
-
-- In the future, to update to the latest version of our SDK, repeat the previous steps.
-
-### 3. Import the SDK module
-
-In the Swift class that you want to use the SDK, please import our SDK module:
-
-```swift
-import Fidel
-```
-
-### 4. Set your SDK Key
+### 3. Set your SDK Key
 
 - Please [sign into](https://dashboard.fidel.uk/sign-in) your Fidel API dashboard account, if you didn't already.
 - Click on your account name _(on the top-left hand side of the dashboard)_ -> then on `Account Settings`.
 - Go to the `Plan` tab and copy your `Test` or `Live` SDK Key.
 - Set your SDK Key in your app:
 
-```swift
+```kotlin
 Fidel.apiKey = "Your-SDK-Key"
 ```
 
-### 5. Set your Program ID
+### 4. Set your Program ID
 
 - Please [sign into](https://dashboard.fidel.uk/sign-in) your Fidel API dashboard account, if you didn't already.
 - Go to the `Programs` section of your Fidel API dashboard.
 - Click on the `Program ID` of the program that you want to enroll cards into. The program ID will be copied to your pasteboard.
 - Set your Program ID in your app:
 
-```swift
-Fidel.programID = "Your-Program-ID"
+```kotlin
+Fidel.programId = "Your-Program-ID"
 ```
 
-### 6. Configure the cardholder consent management feature
+### 5. Configure the cardholder consent management feature
 
 Asking for consent from the cardholder to enroll the card in your program is an important part of the SDK. The cardholder will need to read & agree with the conditions expressed using the consent language displayed during the card enrollment process. Making it clear for cardholders is essential.
 
 #### Set your company name
 
-```swift
+```kotlin
 Fidel.companyName = "Your Company Name"
 ```
 
@@ -118,7 +91,7 @@ You need to set your terms and conditions URL if you would like to:
 a. support all the countries that Fidel API supports
 b. set a specific `allowedCountries` set of countries AND include US or Canada in your set of allowed countries.
 
-```swift
+```kotlin
 Fidel.termsConditionsURL = "https://yourwebsite.com/terms"
 ```
 
@@ -126,13 +99,13 @@ Fidel.termsConditionsURL = "https://yourwebsite.com/terms"
 
 Please inform the cardholder about how to opt out of transaction monitoring in your program.
 
-```swift
+```kotlin
 Fidel.deleteInstructions = "how can the cardholder opt out"
 ```
 
 #### Set your privacy policy (optional, but recommended)
 
-```swift
+```kotlin
 Fidel.privacyURL = "https://yourwebsite.com/privacy-policy"
 ```
 
@@ -146,13 +119,10 @@ If client side notifications are useful for your application, make sure to check
 
 Call the `Fidel.present` function to open the UI and start a card enrollment process:
 
-```swift
-Fidel.present(yourViewController, onCardLinkedCallback: { (card: LinkResult) in
-    print(card.id)
-}, onCardLinkFailedCallback: { (err: LinkError) in
-    print(err.message)
-})
+```kotlin
+Fidel.present(yourStartingActivity)
 ```
+
 You can test the card enrollment flow, by setting a test SDK Key and by using the Fidel API [test card numbers](/docs/select/cards#test-card-numbers).
 
 If your Fidel API account is `live` then cardholders can also enroll real, live cards. Make sure that you set a live SDK Key, in order to allow live card enrollments.
@@ -163,19 +133,20 @@ Please check our SDK Reference for details about any other SDK properties that m
 
 # Frequently asked questions
 
-### How can I upgrade the iOS SDK to the latest version?
+### How can I upgrade the Android SDK to the latest version?
 
-If you integrated the Fidel API iOS SDK into your project using Cocoapods, please run:
+- Check what's the latest version of the Fidel API Android SDK in our Releases documentation page.
 
-`pod update Fidel`
+- Add the latest version of our SDK as a dependency in your app's module `build.gradle` file:
 
-from the folder where your `Podfile` is stored.
+```groovy
+fileName:app/build.gradle
+implementation 'com.github.FidelLimited:android-sdk:{latestFidelSDKVersion}'
+```
 
-If you integrated the SDK manually, please repeat all the steps from the manual framework integration section.
+### Can I customize the UI of the Android SDK?
 
-### Can I customize the UI of the iOS SDK?
-
-The iOS SDK offers the `bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
+The Android SDK offers the `Fidel.bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
 
 ### How do I configure the consent text correctly?
 
@@ -183,27 +154,27 @@ In order to properly set the consent text, please follow these steps:
 
 1. **Set the company name**
 
-The `companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
+The `Fidel.companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
 
 2. **Set the privacy policy URL**
 
-The `privacyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
+The `Fidel.privacyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
 
 3. **Set the delete instructions**
 
-The `deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
+The `Fidel.deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
 
 4. **Set the card scheme name**
 
-You can do so via the `supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
+You can do so via the `Fidel.supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
 
 5. **Set the program name (applied to the consent text specific to the US and Canada)**
 
-The `programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
+The `Fidel.programName` property is taken into account only for the consent text specific to USA and Canada issued cards. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
 
-6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada)**
+6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada issued cards)**
 
-The `termsConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
+The `Fidel.termsConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
 
 ### How is the SDK's consent text formed?
 

--- a/select/sdks/android/guide-v2.md
+++ b/select/sdks/android/guide-v2.md
@@ -1,4 +1,4 @@
-# A guide for card enrollment with the Android SDK
+# A guide for card enrollment with the Android SDK <a style="color: #111;" class="improve-docs" href="/select/sdks/android/guide-v1">v1</a> <a style="margin-right: auto; border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/android/guide-v2">v2</a>
 
 Please take the following steps to integrate and configure the SDK for your Loyalty use case application.
 
@@ -48,7 +48,7 @@ If you didn't create a program for your application yet, please create a Transac
 
 ```groovy
 fileName:app/build.gradle
-implementation 'com.github.FidelLimited:android-sdk:1.7.5'
+implementation 'com.github.FidelLimited:android-sdk:2.0.0'
 ```
 
 - In the future, to update to the latest Android SDK version, please update the version in your `app/build.gradle` file and `Sync` your Android project again.
@@ -61,7 +61,7 @@ implementation 'com.github.FidelLimited:android-sdk:1.7.5'
 - Set your SDK Key in your app:
 
 ```kotlin
-Fidel.apiKey = "Your-SDK-Key"
+Fidel.sdkKey = "Your-SDK-Key"
 ```
 
 ### 4. Set your Program ID
@@ -92,7 +92,7 @@ a. support all the countries that Fidel API supports
 b. set a specific `allowedCountries` set of countries AND include US or Canada in your set of allowed countries.
 
 ```kotlin
-Fidel.termsConditionsURL = "https://yourwebsite.com/terms"
+Fidel.termsAndConditionsUrl = "https://yourwebsite.com/terms"
 ```
 
 #### Explain how the cardholder can opt out (optional, but recommended)
@@ -106,7 +106,7 @@ Fidel.deleteInstructions = "how can the cardholder opt out"
 #### Set your privacy policy (optional, but recommended)
 
 ```kotlin
-Fidel.privacyURL = "https://yourwebsite.com/privacy-policy"
+Fidel.privacyPolicyUrl = "https://yourwebsite.com/privacy-policy"
 ```
 
 # Enrollment notifications
@@ -117,10 +117,10 @@ If client side notifications are useful for your application, make sure to check
 
 # Enroll a card
 
-Call the `Fidel.present` function to open the UI and start a card enrollment process:
+Call the `Fidel.start` function to open the UI and start a card enrollment process:
 
 ```kotlin
-Fidel.present(yourStartingActivity)
+Fidel.start(yourContext)
 ```
 
 You can test the card enrollment flow, by setting a test SDK Key and by using the Fidel API [test card numbers](/docs/select/cards#test-card-numbers).
@@ -146,7 +146,7 @@ implementation 'com.github.FidelLimited:android-sdk:{latestFidelSDKVersion}'
 
 ### Can I customize the UI of the Android SDK?
 
-The Android SDK offers the `bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
+The Android SDK offers the `Fidel.bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
 
 ### How do I configure the consent text correctly?
 
@@ -154,27 +154,27 @@ In order to properly set the consent text, please follow these steps:
 
 1. **Set the company name**
 
-The `companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
+The `Fidel.companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
 
 2. **Set the privacy policy URL**
 
-The `privacyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
+The `Fidel.privacyPolicyUrl` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
 
 3. **Set the delete instructions**
 
-The `deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
+The `Fidel.deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
 
 4. **Set the card scheme name**
 
-You can do so via the `supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
+You can do so via the `Fidel.supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
 
 5. **Set the program name (applied to the consent text specific to the US and Canada)**
 
-The `programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
+The `Fidel.programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
 
-6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada)**
+6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada issued cards)**
 
-The `termsConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
+The `Fidel.termsAndConditionsUrl` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
 
 ### How is the SDK's consent text formed?
 
@@ -186,7 +186,7 @@ The SDK forms two distinct consent texts, depending on the country the cardholde
 
 You are allowing US and Canada issued cards when you:
 1. set United States and/or Canada as `allowedCountries`
-2. don't set a value for the `allowedCountries` property, which means that all countries supported by Fidel API will be included in your SDK implementation (including US & Canada).
+2. don't set a value for the `Fidel.allowedCountries` property, which means that all countries supported by Fidel API will be included in your SDK implementation (including US & Canada).
 
 For USA & Canada, the following would be an example consent text for `Cashback Inc` (an example company) that uses `Awesome Bonus` as their program name:
 

--- a/select/sdks/android/migration-guide.md
+++ b/select/sdks/android/migration-guide.md
@@ -1,0 +1,96 @@
+# Guide to migrate to v2 of the Android SDK for Loyalty applications
+
+## Update your Fidel API Android SDK integration
+
+### If you used Jitpack to integrate the Android SDK
+
+Replace the Fidel dependency inside your app/build.gradle by this one:
+
+```groovy
+implementation 'com.github.FidelLimited:android-sdk:2.0.0'
+```
+
+### If you manually integrated the Android SDK
+
+1. Replace the `FidelSDK.aar` by the latest one. 
+2. Remove the following dependency
+```groovy
+implementation 'io.card:android-sdk:5.5.1'
+```
+3. Add the following dependencies:
+```groovy
+implementation 'com.scottyab:rootbeer-lib:0.1.0'
+implementation 'io.split.client:android-client:2.13.1'
+implementation 'androidx.work:work-runtime-ktx:2.8.1'
+```
+
+## Update the minSdkVersion
+
+Previously the minSdkVersion was `19`. You'll have to update it to `21`, to use the Fidel API Android SDK v2.
+
+## Check the following code as your migration guide
+
+Use the following code as a guide related to the changes that  to integrate with the Fidel API SDK:
+
+```kotlin
+...
+import com.fidelapi.Fidel // was import com.fidel.sdk.Fidel
+//remove all com.fidel.sdk imports
+...
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        Fidel.programId = "Your Program ID"
+        
+        /*
+         * It is recommended to store the SDK key on your backend and retrieve it
+         * before starting to use the SDK.
+         */
+        Fidel.sdkKey = "Your SDK key" // previously apiKey
+        // remove Fidel.autoScan
+        Fidel.allowedCountries = setOf(Country.CANADA, Country.UNITED_STATES, Country.UNITED_KINGDOM)
+        Fidel.supportedCardSchemes = setOf(CardScheme.VISA, CardScheme.MASTERCARD, CardScheme.AMERICAN_EXPRESS)
+        Fidel.companyName = "[Developer company]"
+        Fidel.termsAndConditionsUrl = "https://fidel.uk" // termsConditionsURL
+        Fidel.privacyPolicyUrl = "https://fidel.uk" // was privacyURL
+        Fidel.deleteInstructions = "[Developer set delete instructions]"
+        val jsonMeta = JSONObject()
+        try {
+            jsonMeta.put("id", "this-is-the-metadata-id")
+            jsonMeta.put("customKey1", "customValue1")
+            jsonMeta.put("customKey2", "customValue2")
+        } catch (e: JSONException) {
+            val exceptionMessage = e.localizedMessage
+            if (exceptionMessage != null) {
+                Log.e(FIDEL_DEBUG_TAG, exceptionMessage)
+            }
+        }
+
+        Fidel.metaData = jsonMeta
+        Fidel.bannerImage = ContextCompat.getDrawable(this, R.drawable.fidel_test_banner)?.toBitmap()
+
+        val btn = findViewById<View>(R.id.btn_show) as Button
+        
+        //Fidel.start() replaces Fidel.present()
+        btn.setOnClickListener { Fidel.start(this@MainActivity) }
+        
+        // replaces Fidel.setCardLinkingObserver
+        Fidel.onResult = OnResultObserver { result ->
+            when (result) {
+                is FidelResult.Enrollment -> {
+                    Log.d(FIDEL_DEBUG_TAG, "The card ID = " + result.enrollmentResult.cardId)
+                }
+                is FidelResult.Error -> {
+                    Log.e(FIDEL_DEBUG_TAG, "Error message = " + result.error.message)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        private const val FIDEL_DEBUG_TAG = "fidel.debug"
+    }
+}
+```

--- a/select/sdks/android/reference-v1.md
+++ b/select/sdks/android/reference-v1.md
@@ -1,4 +1,4 @@
-# Android SDK reference
+# Android SDK reference <a style="border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/android/reference-v1">v1</a> <a style="margin-right: auto; color: #111;" class="improve-docs" href="/select/sdks/android/reference-v2">v2</a>
 
 1. [Fidel class](#class-fidel)
 2. [Properties](#properties)
@@ -37,7 +37,7 @@ You need to set your terms and conditions URL if you would like to:
 
 By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Loyalty use case work with your Transaction Select program, please consider setting them correctly.
 
@@ -146,6 +146,12 @@ Depending on what you want to display in the banner image, you might need to exp
 Default value: `"our"`
 
 This value is used in the consent text when enrolling a card issued in United States or Canada. Please set it to a maximum of `60` characters.
+
+#### autoScan: Boolean
+
+Default value: `false`
+
+When set to `true`, automatically starts the card camera scanning UI. After card scanning is finalized, the user will go to the expected card enrollment screen, with the card details prefilled.
 
 ## Methods
 

--- a/select/sdks/android/reference-v2.md
+++ b/select/sdks/android/reference-v2.md
@@ -1,0 +1,274 @@
+# Android SDK reference <a style="color: #111;" class="improve-docs" href="/select/sdks/android/reference-v1">v1</a> <a style="margin-right: auto; border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/android/reference-v2">v2</a>
+
+1. [Fidel class](#class-fidel)
+2. [Properties](#properties)
+3. [Methods](#methods)
+4. [Callbacks](#callbacks)
+
+## class Fidel
+
+This class is designed as a facade, used to configure the card enrollment process, via many of its [static properties](#properties), and start the [card enrollment flow](#methods). It's also the class that provides [callbacks](#callbacks) that might be useful for your application.
+
+## Properties
+
+### Mandatory properties
+
+These are properties that must be set correctly. In the case where one of these properties are not set or they are set incorrectly, the SDK will return an error in the `onResult` callback (of type: `FidelErrorType.SdkConfigurationError`).
+
+#### sdkKey: String
+
+This key is used to authenticate your Fidel API account. Get it from your Fidel API dashboard -> Account Settings -> SDK Keys section.
+
+> Important note: Make sure that you store this key securely (not on the client side).
+
+> Note: If you use a **test SDK Key**, your users can only enroll [test card numbers](/docs/select/cards#test-card-numbers).
+
+#### programId: String
+
+The program ID indicates the Fidel API program in which the cards will be enrolled. Get the program ID by navigating to the Fidel API dashboard -> Programs section -> Click on the ID of the program you want to use. Clicking on it will copy the ID in your pasteboard.
+
+#### companyName: String
+
+By setting this property we customize the consent text, that the cardholder needs to read and agree with, before enrolling a card.
+
+The maximum number of characters allowed for this property is `60`.
+
+#### termsAndConditionsUrl: String
+
+You need to set your terms and conditions URL if you would like to:
+
+1. support all the countries that Fidel API supports
+
+2. set a specific `allowedCountries` set of countries AND include US or Canada in it.
+
+By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
+
+### Optional properties
+
+#### supportedCardSchemes
+
+Type: `Set<CardScheme>`
+
+Default value: `setOf(CardScheme.VISA, CardScheme.MASTERCARD, CardScheme.AMERICAN_EXPRESS)`
+
+Sets a list of supported card schemes. If a card scheme is supported, cardholders will be able to enroll their card. If a card scheme is not in the list, then the cardholders will see an error message while typing or pasting the unsupported card number.
+
+If you set a `null` value, you will not be able to start the Fidel SDK enrollment flow. In this case, immediately after attempting to start the flow, you will receive an error in the `onResult` callback (of type: `FidelErrorType.SdkConfigurationError`).
+
+#### enum class CardScheme
+
+Cases:
+
+- `VISA`, `MASTERCARD`, `AMERICAN_EXPRESS`
+
+#### allowedCountries
+
+Type: `Set<Country>`
+
+Default value: `setOf(Country.CANADA, Country.IRELAND, Country.JAPAN, Country.NORWAY, Country.SWEDEN, Country.UNITED_ARAB_EMIRATES, Country.UNITED_KINGDOM, Country.UNITED_STATES)`
+
+Sets the list of countries that cardholders can pick to be the card issuing country. When two or more countries are set, cardholders will be able to select the card issuing country with our country selection UI.
+
+If you set a value with only one country (`size` of this set == 1), the country selection UI will not be displayed in the card enrollment screen. The country that you set will be considered the card issuing country for all cards enrolled in your Fidel API program using the SDK.
+
+If you set an empty value, you will not be able to start the enrollment flow. Instead you will receive an error in the `onResult` callback (`FidelErrorType.SdkConfigurationError`), immediately after the attempt to start.
+
+##### enum class Country
+
+Cases:
+
+- `CANADA, IRELAND, JAPAN, NORWAY, SWEDEN, UNITED_ARAB_EMIRATES, UNITED_KINGDOM, UNITED_STATES`
+
+#### deleteInstructions: String
+
+Default value: `"going to your account settings"`
+
+This text informs the cardholder how to opt out of transaction monitoring in your program. It is appended at the end of the consent text. The maximum number of characters allowed for this property is `60`.
+
+#### defaultSelectedCountry: Country
+
+Default value: `UNITED_KINGDOM`
+
+Sets the `Country` that will be selected by default when the user opens the card enrollment screen. If the `defaultSelectedCountry` is not part of the `allowedCountries` list, then the first country in the `allowedCountries` list will be selected.
+
+#### privacyPolicyUrl: String?
+
+Default value: `null`.
+
+If you provide a value for this parameter, the card enrollment consent text will include a phrase that will provide the user with more privacy related information at the URL that you provide.
+
+When the value of this parameter remains `null` no such phrase will be displayed in the card enrolling consent text.
+
+If you provide an invalid URL string, you will not be able to start the card enrollment flow. Instead you will receive an error in the `onResult` callback (`FidelErrorType.SdkConfigurationError`), immediately after attempting to start the card enrollment flow.
+
+#### metaData: org.json.JSONObject?
+
+This is a JSONObject that you can use to associate custom data with an enrolled card.
+
+We advise setting an `"id"` key -> value pair in this JSONObject. Later, it might be useful for you to use our [List Cards from Metadata ID](https://reference.fidel.uk/reference/list-cards-from-metadata-id) API Endpoint to query for cards using this ID.
+
+Example of meta data that you can set:
+
+```swift
+val jsonMetaData = JSONObject()
+jsonMetaData.put("id", "this-is-the-metadata-id")
+jsonMetaData.put("myUserId", "123")
+jsonMetaData.put("customKey", "customValue")
+Fidel.metaData = jsonMetaData
+```
+
+You would receive a JSONObject that is equal to this one, after successfully enrolling a card, in the `onResult` callback, in the `EnrollmentResult` object.
+
+#### bannerImage: Bitmap?
+
+Default value: `null`.
+
+Will display the banner image that you set in this parameter at the top of the card details screen.
+
+The banner image will take the device's width, but it has a fixed height of 100 dp.
+The image view has the `android:scaleType="centerCrop"` attribute, which means that the banner image that you set will fill its entire predefined area.
+
+For the banner image that you can set, we suggest to use the aspect ratio of the smallest devices that you support. On wider devices, the banner image will be cropped from top and bottom sides. This is because of the `android:scaleType="centerCrop"` attribute that we set for the image view.
+
+If a device that opens the SDK has 320dp in width, the aspect ratio of the image view would be *320 : 100*.
+If a device that opens the SDK has 475dp in width, the aspect ratio of your banner image would be *475 : 100*.
+
+You need to provide the image for all screen densities.
+
+Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
+
+#### programName: String
+
+Default value: `"our"`
+
+This value is used in the consent text when enrolling a card issued in a United States or Canada.
+
+#### programType: ProgramType
+
+Default value: `ProgramType.TRANSACTION_SELECT`
+
+It specifies the type of program you want to enroll cards into. The `ProgramType` influences the flow that the SDK will show to cardholders when enrolling cards. 
+
+> Note: For your Loyalty application, you need to use a Transaction Select program, so you can either explicitly set the value to `TRANSACTION_SELECT` or not set this property (because its default value is `TRANSACTION_SELECT`).
+
+#### thirdPartyVerificationChoice: Boolean
+
+Default value: `false`.
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+## Methods
+
+### start(context: Context)
+
+Starts a card enrollment flow. If you set the `programType` to:
+1. `TRANSACTION_STREAM`, a card enrollment flow will be started, for a Transaction Stream program (usually used by Expense Management applications).
+2. `TRANSACTION_SELECT`, a regular card enrollment flow will be started, for your Transaction Select program (usually used by Loyalty applications).
+
+#### Parameters
+
+- `context: Context`: the `Context` that will start the card enrollment flow. This is a *mandatory* parameter.
+
+### verifyCard(context: Context, cardVerificationConfiguration: CardVerificationConfiguration)
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+### onMainActivityCreate(context: Context)
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+## Callbacks
+
+The SDK provides the following callbacks:
+
+### onResult: OnResultObserver
+
+The `OnResultObserver` interface has a single function.
+
+```kotlin
+fun onResultAvailable(result: FidelResult)
+```
+
+It will be called when a `FidelResult` is available, during the card enrollment process. It can be called multiple times with different types of results.
+
+#### sealed class FidelResult
+
+Types of results:
+
+- `Enrollment(val enrollmentResult: EnrollmentResult)`: Received after successfully enrolling the card in your Fidel API program. Please find details about `EnrollmentResult` below.
+- `Verification(val verificationResult: VerificationResult)`._Not useful for Loyalty/Select Transactions use cases, at the moment._
+- `Error(val error: FidelError)`. An error occurred either during the card enrollment process. Please find details about `FidelError` below.
+
+#### data class EnrollmentResult
+
+A result that can be received via the `onResult` callback, after a card is successfully enrolled in your Fidel API program.
+
+Properties:
+- `cardId: String`: The identifier of the card enrolled with your Fidel API program.
+- `accountId: String`: The Fidel API account identifier.
+- `programId: String`: The identifier of the program that the card was enrolled into.
+- `enrollmentDate: Long`: The date and time when the card was enrolled, expressed as a `Long` value, that you can use with your preferred date & time APIs.
+- `scheme: CardScheme`: The enrolled card's scheme.
+- `isLive: Boolean`: This property will be `true` when your Fidel API account is live and the card was enrolled in your `live` Fidel API program. If the program that you enrolled the card into is not a `live` one, then this property will be `false`.
+- `cardFirstNumbers: String?`: If available, this property will be populated with the first 6 numbers of the enrolled card. To turn on or off receiving these numbers, please check your Fidel API account's settings.
+- `cardLastNumbers: String?`: If available, this property will be populated with the last 4 numbers of the enrolled card. To turn on or off receiving these numbers, please check your Fidel API account's settings.
+- `cardExpirationYear: Int`: The expiration year of the enrolled card. The values are four digit year values (ex: 2031), **not** shortened, two digit values (ex: 31).
+- `cardExpirationMonth: Int`: The expiration month of the enrolled card. The values start with `1` (January) and end with `12` (December).
+- `cardIssuingCountry: Country`: The country where the enrolled card was issued.
+- `metaData: JSONObject?`: Custom data assigned to the enrolled card via the `metaData` SDK property.
+
+#### data class VerificationResult
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+#### data class FidelError
+
+A FidelError can occur during the card enrollment process. You can handle them via the `onResult` callback.
+
+Properties:
+
+- `message: String`: An error message explaining more details about the error. It is not localized.
+- `date: Long`: The date and time when the error occurred, expressed as a `Long` value. You can use it with your preferred date & time APIs.
+- `type: FidelErrorType`: The type of the error. Please check more details about `FidelErrorType` below.
+
+#### sealed class FidelErrorType
+
+Types of errors:
+
+- `SdkConfigurationError`: The SDK [properties](#properties) configuration is incorrect or incomplete. You can receive this error as soon as you attempt to start a flow using the SDK [methods](#methods).
+- `UserCanceled`: The user canceled the card enrollment flow at any stage.
+- `DeviceNotSecure`: The device that the SDK is running on is not secure (for example, when it is rooted).
+- `EnrollmentError(val type: EnrollmentErrorType)`. An error that is received during card enrollment or during consent creation. Please check more details about `EnrollmentErrorType` below.
+- `VerificationError(val type: VerificationErrorType)`. _Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+#### enum class EnrollmentErrorType
+
+An enum containing some of the cases of card enrollment errors.
+
+Cases:
+
+- `CARD_ALREADY_EXISTS`: The card was already enrolled in your Fidel API program. This error is equivalent to the Fidel API error with the code `map.already.exists`.
+- `INVALID_PROGRAM_ID`: The program ID used to configure the SDK is not valid. If you receive this error, please make sure that you set a valid program ID via the `programId` property. This error is equivalent to the Fidel API error with the code `map.already.exists`.
+- `INVALID_SDK_KEY`: The SDK Key used to configure the Fidel SDK is not valid. If you receive this error, please make sure that you set a valid SDK Key via the `sdkKey` property. This error is equivalent to the Fidel API error with the code `credential`.
+- `INEXISTENT_PROGRAM`: The program ID used to configure the Fidel SDK is of a program that does not exist. If you receive this error, please make sure that you set the correct program ID via the `programId` property. This error is equivalent to the Fidel API error with the code `item-exists`.
+- `UNAUTHORIZED`: The card enrollment process is not authorized. This error is equivalent to the Fidel API error with the code `Unauthorized`.
+- `UNEXPECTED`: An unexpected error during the card enrollment step.
+
+The following list of cases are _not used_ by Loyalty/Select Transactions use cases, at the moment, so you can ignore them:
+
+- `CARD_CONSENT_ISSUER_PROCESSING_CHARGE_ERROR`
+- `CARD_CONSENT_DUPLICATE_TRANSACTION_ERROR`
+- `CARD_CONSENT_INSUFFICIENT_FUNDS_ERROR`
+- `CARD_CONSENT_PROCESSING_CHARGE_ERROR`
+- `CARD_CONSENT_INCORRECT_CARD_DETAILS_ERROR`
+- `CARD_CONSENT_CARD_LIMIT_EXCEEDED`
+- `CARD_CONSENT_ERROR_GENERIC`
+
+
+### onCardVerificationStarted: OnCardVerificationStartedObserver
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+### onCardVerificationChoiceSelected: OnCardVerificationChoiceSelectedObserver _(!Experimental)_
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._

--- a/stream/sdks/android/reference.md
+++ b/stream/sdks/android/reference.md
@@ -37,7 +37,7 @@ The maximum number of characters allowed for this property is `60`.
 
 By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Expense Management use case work with your Transaction Stream program, please consider setting them correctly.
 
@@ -200,6 +200,14 @@ Properties:
 - `consentId: String` - The card consent identifier used for card verification.
 - `last4Digits: String?` - The last 4 digits of a card. If set, the verification screen will display them to visually help the the card verifier identify which card is being verified. If not set, the verification screen will be more generic. This property is *optional*.
 
+### onMainActivityCreate(context: Context)
+
+It reports to the SDK that the main Activity of your application was created. At this function call, for card verification success purposes, the SDK might decide to resume the verification process for a card didn't finish it.
+
+#### Parameters
+
+- `context: Context`. This is a *mandatory* parameter.
+
 ## Callbacks
 
 The SDK provides the following callbacks:
@@ -250,7 +258,7 @@ Properties:
 
 #### data class FidelError
 
-A FidelError can occur during the card enrollment, card consent creation or card verification processes. You can handle them via the `onResult` callback.
+A FidelError can occur during the card enrollment, card consent creation or card verification processes. You can handle it via the `onResult` callback.
 
 Properties:
 


### PR DESCRIPTION
Changelog:
- Fix wording and include a bit more docs in the Select v1 docs & make a few corrections in the Stream docs
- Add Select v2 docs for the Android SDK.

#### Steps to test

- Go to the website project.
- Run `env DOCS_BRANCH=this-pr-branch yarn docs` to download the docs files from this PR.
- Run `yarn start` and go to `/docs` to check the changes.
