### PR TITLE
Feat/CLET-59 Add v2 iOS SDK Select Transactions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # Fidel documentation
 
 This repository is the home for the Fidel documentation located [here](https://fidel.uk/docs/). The format of this documentation is [MDX](https://mdxjs.com/), this enhances standard markdown with functionality that enables us to create richer and more interactive documentation. MDX is indicated by the presence of `<Tags>` within these files. If you wish to contribute please be aware of this, in most cases you should not need to touch any MDX however if you do we will assist you in the pull request.
+
+## Steps to test the docs on your local machine
+
+1. Clone the [website](https://github.com/FidelLimited/website/) project.
+
+2. Install libraries, dependencies & follow the instructions that indicate how to run the website on your local machine, as written in the [README.md file](https://github.com/FidelLimited/website/blob/master/README.md) of the website project.
+
+3. From the website's project root folder:
+    
+    a. Run `env DOCS_BRANCH=the-docs-repo-branch-you-want-to-test yarn docs` to download the docs files from a docs repo branch.
+
+    b. Go to src/pages/docs to check the changes in the docs' files.
+    
+    c. Run `yarn start` to build the project
+
+4. Wait until you see a message giving you a localhost URL that can be used to test the website. It should be something like the following:
+
+```
+You can now view fidelapi.com in the browser.
+
+  http://localhost:8000/
+```
+5. Open `http://localhost:8000/` in your browser.
+
+6. Make any changes in the `src/templates/docs/routes.ts` file, if the navigation to your documentation pages has changed or if you added new pages.

--- a/select/sdks/ios/guide-v1.md
+++ b/select/sdks/ios/guide-v1.md
@@ -1,0 +1,236 @@
+# A guide for card enrollment with the iOS SDK <a style="border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/ios/guide-v1">v1</a> <a style="margin-right: auto; color: #111;" class="improve-docs" href="/select/sdks/ios/guide-v2">v2</a>
+
+Please take the following steps to integrate and configure the SDK for your Loyalty use case application.
+
+> Note: If an example project helps with your SDK integration & configuration, please check our [GitHub repository](https://github.com/FidelLimited/fidel-ios/).
+
+### 1. Set up your Fidel API account & your Transaction Select program
+
+To get started, you'll need a Fidel API account. [Sign up](https://dashboard.fidel.uk/sign-up), if you didn't create an account yet.
+
+If you didn't create a program for your application yet, please create a Transaction Select program from your Fidel API dashboard (or via the API).
+
+### 2. Integrate the iOS SDK into your project
+
+#### Using Cocoapods
+> Info: If you prefer *not* to use Cocoapods, please check our instructions about integrating the SDK manually below.
+
+- Install [CocoaPods](https://cocoapods.org/), if you haven't already.
+
+- If your iOS project does not use Cocoapods (it does not contain a `Podfile` file), run the following command to initialize it:
+
+```
+pod init
+```
+
+- Add the following line in your `Podfile`, representing the Fidel API iOS SDK dependency that you're adding to your project:
+
+```ruby
+pod 'Fidel'
+```
+
+Your `Podfile` should have a structure similar to the following:
+```ruby
+fileName:Podfile
+platform :ios, '9.1'
+
+target 'YouriOSTarget' do
+    use_frameworks!
+
+    pod 'Fidel'
+    # ... other pods, if you're using Cocoapods already
+end
+```
+
+- Run the following command to install the Fidel API iOS SDK dependency:
+
+```
+pod install
+```
+
+- To start working with the Fidel API iOS SDK in your project, from now on, please don't forget to open your project's `.xcworkspace` file, not the `.xcodeproj` file. The `.xcworkspace` file is created by Cocoapods, when running the previous command.
+
+- In the future, to update to the latest iOS SDK version, please run:
+
+```
+pod update Fidel
+```
+
+> Note: For information about all the Fidel API iOS SDK versions that are used by loyalty use case applications, please check our Releases page.
+
+#### Manual framework integration
+
+> Info: If you prefer to use Cocoapods, please check our instructions about [integrating the SDK using Cocoapods](#using-cocoapods).
+
+- Download the latest version of the `Fidel.xcframework` artefact from the `master` branch of our [GitHub repo](https://github.com/FidelLimited/fidel-ios).
+
+- Open your iOS app project in Xcode.
+
+- Right click on your project and then on the `Add Files to "YourProjectName"...` button.
+
+- Select the `Fidel.xcframework` artefact. Make sure to select the `Copy items if needed` option.
+
+- In the future, to update to the latest version of our SDK, repeat the previous steps.
+
+### 3. Import the SDK module
+
+In the Swift class that you want to use the SDK, please import our SDK module:
+
+```swift
+import Fidel
+```
+
+### 4. Set your SDK Key
+
+- Please [sign into](https://dashboard.fidel.uk/sign-in) your Fidel API dashboard account, if you didn't already.
+- Click on your account name _(on the top-left hand side of the dashboard)_ -> then on `Account Settings`.
+- Go to the `Plan` tab and copy your `Test` or `Live` SDK Key.
+- Set your SDK Key in your app:
+
+```swift
+Fidel.apiKey = "Your-SDK-Key"
+```
+
+### 5. Set your Program ID
+
+- Please [sign into](https://dashboard.fidel.uk/sign-in) your Fidel API dashboard account, if you didn't already.
+- Go to the `Programs` section of your Fidel API dashboard.
+- Click on the `Program ID` of the program that you want to enroll cards into. The program ID will be copied to your pasteboard.
+- Set your Program ID in your app:
+
+```swift
+Fidel.programId = "Your-Program-ID"
+```
+
+### 6. Configure the cardholder consent management feature
+
+Asking for consent from the cardholder to enroll the card in your program is an important part of the SDK. The cardholder will need to read & agree with the conditions expressed using the consent language displayed during the card enrollment process. Making it clear for cardholders is essential.
+
+#### Set your company name
+
+```swift
+Fidel.companyName = "Your Company Name"
+```
+
+#### To support US or Canada issued cards, please set your terms and conditions
+
+You need to set your terms and conditions URL if you would like to:
+a. support all the countries that Fidel API supports
+b. set a specific `allowedCountries` set of countries AND include US or Canada in it.
+
+```swift
+Fidel.termsConditionsURL = "https://yourwebsite.com/terms"
+```
+
+#### Explain how the cardholder can opt out (optional, but recommended)
+
+Please inform the cardholder about how to opt out of transaction monitoring in your program.
+
+```swift
+Fidel.deleteInstructions = "how can the cardholder opt out"
+```
+
+#### Set your privacy policy URL (optional, but recommended)
+
+```swift
+Fidel.privacyURL = "https://yourwebsite.com/privacy-policy"
+```
+
+# Enrollment notifications
+
+In order to be notified about different, useful events (a card was linked, card failed to link etc.) that happen during a enrollment process, we recommend using our webhooks.
+
+If client side notifications are useful for your application, make sure to check our SDK callback reference documentation.
+
+# Enroll a card
+
+Call the `Fidel.present` function to open the UI and start a card enrollment process:
+
+```swift
+Fidel.present(yourViewController, onCardLinkedCallback: { (card: LinkResult) in
+    print(card.id)
+}, onCardLinkFailedCallback: { (err: LinkError) in
+    print(err.message)
+})
+```
+You can test the card enrollment flow, by setting a test SDK Key and by using the Fidel API [test card numbers](/docs/select/cards#test-card-numbers).
+
+If your Fidel API account is `live` then cardholders can also enroll real, live cards. Make sure that you set a live SDK Key, in order to allow live card enrollments.
+
+# Optional: Set any of the other useful properties
+
+Please check our SDK Reference for details about any other SDK properties that might be useful for your application.
+
+# Frequently asked questions
+
+### How can I upgrade the iOS SDK to the latest version?
+
+If you integrated the Fidel API iOS SDK into your project using Cocoapods, please run:
+
+`pod update Fidel`
+
+from the folder where your `Podfile` is stored.
+
+If you integrated the SDK manually, please repeat all the steps from the manual framework integration section.
+
+### Can I customize the UI of the iOS SDK?
+
+The iOS SDK offers the `Fidel.bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
+
+### How do I configure the consent text correctly?
+
+In order to properly set the consent text, please follow these steps:
+
+1. **Set the company name**
+
+The `Fidel.companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
+
+2. **Set the privacy policy URL**
+
+The `Fidel.privacyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
+
+3. **Set the delete instructions**
+
+The `Fidel.deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
+
+4. **Set the card scheme name**
+
+You can do so via the `Fidel.supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
+
+5. **Set the program name (applied to the consent text specific to the US and Canada)**
+
+The `Fidel.programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
+
+6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada)**
+
+The `Fidel.termsConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
+
+### How is the SDK's consent text formed?
+
+The SDK forms two distinct consent texts, depending on the country the cardholder selects as the card issuing country:
+1. A specific consent text for US and Canada
+2. Another consent text for the other countries supported by Fidel API.
+
+#### Consent text for United States and Canada
+
+You are allowing US and Canada issued cards when you:
+1. set United States and/or Canada as Fidel.`allowedCountries`
+2. don't set a value for the `Fidel.allowedCountries` property, which means that all countries supported by Fidel API will be included in your SDK implementation (including US & Canada).
+
+For USA & Canada, the following would be an example consent text for `Cashback Inc` (an example company) that uses `Awesome Bonus` as their program name:
+
+_By submitting your card information and checking this box, you authorize `card_scheme_name` to monitor and share transaction data with Fidel API (our service provider) to participate in `Awesome Bonus` program. You also acknowledge and agree that Fidel API may share certain details of your qualifying transactions with `Cashback Inc` to enable your participation in `Awesome Bonus` program and for other purposes in accordance with the `Cashback Inc` Terms and Conditions, `Cashback Inc` privacy policy and Fidel’s Privacy Policy. You may opt-out of transaction monitoring on the linked card at any time by `deleteInstructions`._
+
+#### Consent text for the other Fidel API supported countries
+
+When you allow countries other than US & Canada and the user selects one of these countries from the list of card issuing countries, a consent text specific for these countries will be applied.
+
+The following would be an example Terms & Conditions text for `Cashback Inc` (an example company):
+
+_I authorise `card_scheme_name` to monitor my payment card to identify transactions that qualify for a reward and for `card_scheme_name` to share such information with `Cashback Inc`, to enable my card linked offers and target offers that may be of interest to me. For information about `Cashback Inc` privacy practices, please see the privacy policy. You may opt-out of transaction monitoring on the payment card you entered at any time by `deleteInstructions`._
+
+### Is the SDK localized?
+
+The SDK's default language is English, but it's also localized for French and Swedish languages. When the device has either `Français (Canada)` or `Svenska (Sverige)` as its language, the appropriate texts will be displayed.
+
+Please make sure that your project also supports localization for the languages that you want to support.

--- a/select/sdks/ios/guide-v2.md
+++ b/select/sdks/ios/guide-v2.md
@@ -1,4 +1,4 @@
-# A guide for card enrollment with the iOS SDK
+# A guide for card enrollment with the iOS SDK <a style="color: #111;" class="improve-docs" href="/select/sdks/ios/guide-v1">v1</a> <a style="margin-right: auto; border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/ios/guide-v2">v2</a>
 
 Please take the following steps to integrate and configure the SDK for your Loyalty use case application.
 
@@ -32,7 +32,7 @@ pod 'Fidel'
 Your `Podfile` should have a structure similar to the following:
 ```ruby
 fileName:Podfile
-platform :ios, '14'
+platform :ios, '9.1'
 
 target 'YouriOSTarget' do
     use_frameworks!
@@ -88,7 +88,7 @@ import Fidel
 - Set your SDK Key in your app:
 
 ```swift
-Fidel.apiKey = "Your-SDK-Key"
+Fidel.sdkKey = "Your-SDK-Key"
 ```
 
 ### 5. Set your Program ID
@@ -116,10 +116,10 @@ Fidel.companyName = "Your Company Name"
 
 You need to set your terms and conditions URL if you would like to:
 a. support all the countries that Fidel API supports
-b. set a specific `allowedCountries` set of countries AND include US or Canada in your set of allowed countries.
+b. set a specific `allowedCountries` set of countries AND include US or Canada in it.
 
 ```swift
-Fidel.termsConditionsURL = "https://yourwebsite.com/terms"
+Fidel.termsAndConditionsURL = "https://yourwebsite.com/terms"
 ```
 
 #### Explain how the cardholder can opt out (optional, but recommended)
@@ -130,10 +130,10 @@ Please inform the cardholder about how to opt out of transaction monitoring in y
 Fidel.deleteInstructions = "how can the cardholder opt out"
 ```
 
-#### Set your privacy policy (optional, but recommended)
+#### Set your privacy policy URL (optional, but recommended)
 
 ```swift
-Fidel.privacyURL = "https://yourwebsite.com/privacy-policy"
+Fidel.privacyPolicyURL = "https://yourwebsite.com/privacy-policy"
 ```
 
 # Enrollment notifications
@@ -144,14 +144,10 @@ If client side notifications are useful for your application, make sure to check
 
 # Enroll a card
 
-Call the `Fidel.present` function to open the UI and start a card enrollment process:
+Call the `Fidel.start` function to open the UI and start a card enrollment process:
 
 ```swift
-Fidel.present(yourViewController, onCardLinkedCallback: { (card: LinkResult) in
-    print(card.id)
-}, onCardLinkFailedCallback: { (err: LinkError) in
-    print(err.message)
-})
+Fidel.start(from: yourViewController)
 ```
 You can test the card enrollment flow, by setting a test SDK Key and by using the Fidel API [test card numbers](/docs/select/cards#test-card-numbers).
 
@@ -175,7 +171,7 @@ If you integrated the SDK manually, please repeat all the steps from the manual 
 
 ### Can I customize the UI of the iOS SDK?
 
-The iOS SDK offers the `bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
+The iOS SDK offers the `Fidel.bannerImage` property for you to set a custom, branded banner image that will be displayed during the card enrollment process. Please check our Reference documentation for more details.
 
 ### How do I configure the consent text correctly?
 
@@ -183,27 +179,27 @@ In order to properly set the consent text, please follow these steps:
 
 1. **Set the company name**
 
-The `companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
+The `Fidel.companyName` property is optional, but we recommended setting it. If you don't set a company name, we'll show the default value in the consent text: `Your Company Name`.
 
 2. **Set the privacy policy URL**
 
-The `privacyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
+The `Fidel.privacyPolicyURL` property is optional. It is added as a hyperlink to the `privacy policy` text. Please check the full behavior below.
 
 3. **Set the delete instructions**
 
-The `deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
+The `Fidel.deleteInstructions` property is optional. The default value is `going to your account settings`. This default value is applied for both consent texts that the SDK forms.
 
 4. **Set the card scheme name**
 
-You can do so via the `supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
+You can do so via the `Fidel.supportedCardSchemes` property. By default, we allow the user to input card numbers from either Visa, Mastercard or American Express, but you can control which card networks you accept. The consent text changes based on what you define or based on what the user inputs. Please check the full behavior below.
 
 5. **Set the program name (applied to the consent text specific to the US and Canada)**
 
-The `programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
+The `Fidel.programName` property is taken into account only for the consent text specific to USA and Canada. If you don't plan to support USA nor Canada, you can ignore this property. The default value for program name is `our`.
 
 6. **Set the terms and conditions URL (applied to the consent text only for USA and Canada)**
 
-The `termsConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
+The `Fidel.termsAndConditionsURL` property is mandatory for the SDK if you plan to support USA and Canada issued cards. Once set, it will be applied as a hyperlink on the `Terms and Conditions` text.
 
 ### How is the SDK's consent text formed?
 
@@ -214,8 +210,8 @@ The SDK forms two distinct consent texts, depending on the country the cardholde
 #### Consent text for United States and Canada
 
 You are allowing US and Canada issued cards when you:
-1. set United States and/or Canada as `allowedCountries`
-2. don't set a value for the `allowedCountries` property, which means that all countries supported by Fidel API will be included in your SDK implementation (including US & Canada).
+1. set United States and/or Canada as allowed countries, via the `Fidel.allowedCountries` property.
+2. don't set a value for the `Fidel.allowedCountries` property, which means that all countries supported by Fidel API will be included in your SDK implementation (including US & Canada).
 
 For USA & Canada, the following would be an example consent text for `Cashback Inc` (an example company) that uses `Awesome Bonus` as their program name:
 

--- a/select/sdks/ios/migration-guide.md
+++ b/select/sdks/ios/migration-guide.md
@@ -1,0 +1,97 @@
+# Guide to migrate to v2 of the iOS SDK for Loyalty applications
+
+This is a guide to help you migrate from version 1.x.x of the Fidel API iOS SDK to version 2.0.0.
+
+## Update your Fidel API iOS SDK integration
+
+### If you used Cocoapods to integrate iOS SDK
+
+Update to v2 of the iOS SDK by running the following Cocoapods command, from the root folder of your Xcode project.
+
+```
+pod update Fidel
+```
+
+You should see in the log the version to which the iOS SDK is updated to.
+
+### If you manually integrated the iOS SDK
+
+1. Download the latest `Fidel.xcframework` artefact from the [iOS SDK GitHub repo](https://github.com/FidelLimited/fidel-ios).
+2. Replace your existing `Fidel.xcframework` with the one you downloaded.
+
+## Check the following code as your migration guide
+
+Use the following code as a guide related to the changes that to integrate with the Fidel API SDK:
+
+```swift
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        configureFidel()
+        return true
+    }
+    
+    private func configureFidel() {
+        Fidel.sdkKey = "Your Fidel SDK Key" //was apiKey
+        Fidel.programID = "Your program ID" //was programId
+        Fidel.bannerImage = UIImage(named: "fdl_test_banner")
+        // Remove Fidel.autoScan
+        Fidel.metaData = [
+            "id": "this-is-the-metadata-id",
+            "myUserId": 123,
+            "myUserId2": 123.3,
+            "myUserId3": [12, nil],
+            "myUserId4": ["subkey": 12.2, "subkey2": true],
+            "customKey1": "customValue1"
+        ]
+        Fidel.allowedCountries = [.canada, .unitedStates]
+        Fidel.companyName = "Cashback Inc."
+        Fidel.privacyPolicyURL = "https://www.fidel.uk/" // was privacyURL
+        Fidel.termsAndConditionsURL = "https://fidel.uk/docs/" //was termsConditionsURL
+        Fidel.deleteInstructions = "contacting our support team"
+        Fidel.supportedCardSchemes = [.visa, .mastercard, .americanExpress]
+        Fidel.onResult = self.onResult // result callback
+    }
+    
+    func onResult(_ result: FidelResult) {
+        switch result {
+        case .enrollmentResult(let enrollmentResult):
+            print(enrollmentResult.cardID)
+        case .error(let fidelError):
+            switch fidelError.type {
+            case .enrollmentError(let enrollmentError):
+                switch enrollmentError {
+                case .cardAlreadyExists:
+                    print("card was already enrolled")
+                default:
+                    print("other enrollment error")
+                }
+            case .sdkConfigurationError:
+                print("the SDK should be provided with all the information")
+            case .userCanceled:
+                print("the user cancelled the flow")
+        case .deviceNotSecure:
+            print("the device you’re using is not secure")
+            @unknown default:
+                print("unknown error")
+            }
+        @unknown default:
+            print("unknown result")
+        }
+    }
+}
+```
+
+## Starting the card-linking flow
+
+On any action that you want (on a tap of a button, for example), add the following code: 
+
+```swift
+Fidel.start(from: yourViewController)
+```
+
+The `Fidel.start` method replaces the previous: `Fidel.present` method. To get notified about card enrollment events, you ca use the `Fidel.onResult` callback. Please check our v2 Reference documentation for more details.

--- a/select/sdks/ios/reference-v1.md
+++ b/select/sdks/ios/reference-v1.md
@@ -1,4 +1,4 @@
-# iOS SDK reference
+# iOS SDK reference <a style="border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/ios/reference-v1">v1</a> <a style="margin-right: auto; color: #111;" class="improve-docs" href="/select/sdks/ios/reference-v2">v2</a>
 
 1. [Fidel class](#class-fidel)
 2. [Properties](#properties)
@@ -33,11 +33,11 @@ You need to set your terms and conditions URL if you would like to:
 
 1. support all the countries that Fidel API supports
 
-2. set a specific `allowedCountries` set of countries AND include US or Canada in your set of allowed countries.
+2. set a specific `allowedCountries` set of countries AND include US or Canada in it.
 
 By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Loyalty use case work with your Transaction Select program, please consider setting them correctly.
 
@@ -148,6 +148,12 @@ Depending on what you want to display in the banner image, you might need to exp
 Default value: `"our"`
 
 This value is used in the consent text when enrolling a card issued in United States or Canada. Please set it to a maximum of `60` characters.
+
+#### autoScan: Bool
+
+Default value: `false`
+
+When set to `true`, automatically starts the card camera scanning UI. After card scanning is finalized, the user will go to the expected card enrollment screen, with the card details prefilled.
 
 ## Methods
 

--- a/select/sdks/ios/reference-v2.md
+++ b/select/sdks/ios/reference-v2.md
@@ -1,0 +1,262 @@
+# iOS SDK reference <a style="color: #111;" class="improve-docs" href="/select/sdks/ios/reference-v1">v1</a> <a style="margin-right: auto; border-bottom: 2px solid #0048ff;" class="improve-docs" href="/select/sdks/ios/reference-v2">v2</a>
+
+1. [Fidel class](#class-fidel)
+2. [Properties](#properties)
+3. [Methods](#methods)
+4. [Callbacks](#callbacks)
+
+## class Fidel
+
+This class is designed as a facade, used to configure the card enrollment process, via many of its [static properties](#properties), and start the [card enrollment flow](#methods). It's also the class that provides [callbacks](#callbacks) that might be useful for your application.
+
+## Properties
+
+### Mandatory properties
+
+These are properties that must be set correctly. In the case where one of these properties are not set or they are set incorrectly, the SDK will return an error in the `onResult` callback (of type: `FidelErrorType.sdkConfigurationError`).
+
+#### sdkKey: String
+
+This key is used to authenticate your Fidel API account. Get it from your Fidel API dashboard -> Account Settings -> SDK Keys section.
+
+> Important note: Make sure that you store this key securely (not on the client side).
+
+> Note: If you use a **test SDK Key**, your users can only enroll [test card numbers](/docs/select/cards#test-card-numbers).
+
+#### programID: String
+
+The program ID indicates the Fidel API program in which the cards will be enrolled. Get the program ID by navigating to the Fidel API dashboard -> Programs section -> Click on the ID of the program you want to use. Clicking on it will copy the ID in your pasteboard.
+
+#### companyName: String
+
+By setting this property we customize the consent text, that the cardholder needs to read and agree with, before enrolling a card.
+
+The maximum number of characters allowed for this property is `60`.
+
+#### termsAndConditionsURL: String
+
+You need to set your terms and conditions URL if you would like to:
+
+1. support all the countries that Fidel API supports
+
+2. set a specific `allowedCountries` set of countries AND include US or Canada in it.
+
+By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
+
+### Optional properties
+
+#### supportedCardSchemes
+
+Type: `Set<CardScheme>`
+
+Default value: `[.visa, .mastercard, .americanExpress]`
+
+Sets a list of supported card schemes. If a card scheme is supported, cardholders will be able to enroll their card. If a card scheme is not in the list, then the cardholders will see an error message while typing or pasting the unsupported card number.
+
+If you set a `nil` value, you will not be able to start the card enrollment flow. In this case, immediately after attempting to start the flow, you will receive an error in the `onResult` callback (of type: `FidelErrorType.sdkConfigurationError`).
+
+#### enum CardScheme
+
+Cases:
+
+- `visa`, `mastercard`, `americanExpress`
+
+#### allowedCountries
+
+Type: `Set<Country>`
+
+Default value: `[.canada, .ireland, .japan, .unitedKingdom, .unitedStates, .sweden, .unitedArabEmirates, .norway]`
+
+Sets the list of countries that cardholders can pick to be the card issuing country. When two or more countries are set, cardholders will be able to select the card issuing country with our country selection UI.
+
+If you set a value with only one country (`count` of this set == 1), the country selection UI will not be displayed in the card enrollment screen. The country that you set will be considered the card issuing country for all cards enrolled in your Fidel API program using the SDK.
+
+If you set an empty value, you will not be able to start the enrollment flow. Instead you will receive an error in the `onResult` callback (`FidelErrorType.sdkConfigurationError`), immediately after the attempt to start.
+
+See more: [Country](#enum-country)
+
+#### enum Country
+
+Cases:
+
+- `canada`, `ireland`, `japan`, `norway`, `sweden`, `unitedArabEmirates`, `unitedKingdom`, `unitedStates`
+
+#### deleteInstructions: String
+
+Default value: `"going to your account settings"`
+
+This text informs the cardholder how to opt out of transaction monitoring in your program. It is appended at the end of the consent text. The maximum number of characters allowed for this property is `60`.
+
+#### defaultSelectedCountry: Country
+
+Default value: `.unitedKingdom`
+
+Sets the `Country` that will be selected by default when the user opens the card enrollment screen. If the `defaultSelectedCountry` is not part of the `allowedCountries` list, then the first country in the `allowedCountries` list will be selected.
+
+#### privacyPolicyURL: String?
+
+Default value: `nil`.
+
+If you provide a value for this parameter, the card enrollment consent text will include a phrase that will provide the user with more privacy related information at the URL that you provide.
+
+When the value of this parameter remains `nil` no such phrase will be displayed in the card enrolling consent text.
+
+If you provide an invalid URL string, you will not be able to start the card enrollment flow. Instead you will receive an error in the `onResult` callback (`FidelErrorType.sdkConfigurationError`), immediately after attempting to start the card enrollment flow.
+
+#### metaData: [String: Any]?
+
+This is a dictionary that you can use to associate custom data with an enrolled card.
+
+We advise setting an `"id"` key -> value pair in this dictionary. Later, it might be useful for you to use our [List Cards from Metadata ID](https://reference.fidel.uk/reference/list-cards-from-metadata-id) API Endpoint to query for cards using this ID.
+
+Example of meta data that you can set:
+
+```swift
+Fidel.metaData = [
+    "id": "this-is-the-metadata-id",
+    "myUserId": "123",
+    "customKey1": "customValue1"
+]
+```
+
+You would receive a dictionary equal to this one, after successfully enrolling a card, in the `onResult` callback, in the `EnrollmentResult` object.
+
+#### bannerImage: UIImage?
+
+Default value: `nil`.
+
+Will display the banner image that you set in this parameter at the top of the card details screen.
+
+The banner image will take the device's width, but it has a fixed height of 100 pts.
+The image view has an `Aspect Fill` content mode, which means that the banner image that you set will fill its entire predefined area, while keeping the aspect ratio.
+
+For the banner image that you can set, we suggest to use the aspect ratio of the smallest devices that you support. On wider devices, the banner image will be cropped from top and bottom sides. This is because of the `Aspect Fill` content mode that we set for the image view.
+
+If you support 4" iPhones (iPhone 5s, 5c etc.), the aspect ratio would be *320 : 100*.
+If the smallest device that you support is 4.7" iPhones (iPhone 6, 7, 8 etc.),
+the aspect ratio of your banner image would be *375 : 100*.
+
+You need to provide the image for all screen densities (x1, x2 and x3).
+
+Depending on what you want to display in the banner image, you might need to experiment a bit to make sure that nothing important from the image is hidden. The most important information should be displayed in the centre of the banner image.
+
+#### programName: String
+
+Default value: `"our"`
+
+This value is used in the consent text when enrolling a card issued in a United States or Canada.
+
+#### programType: ProgramType
+
+Default value: `.transactionSelect`
+
+It specifies the type of program you want to enroll cards into. The `ProgramType` influences the flow that the SDK will show to cardholders when enrolling cards. 
+
+> Note: For your Loyalty application, you need to use a Transaction Select program, so you can either explicitly set the value to `.transactionSelect` or not set this property (because its default value is `.transactionSelect`).
+
+#### thirdPartyVerificationChoice: Bool
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._ 
+
+## Methods
+
+### start(from:)
+
+Starts a card enrollment flow. If you set the `programType` to:
+1. `.transactionStream`, a verified card enrollment flow will be started, for a Transaction Stream program (usually used by Expense Management applications).
+2. `.transactionSelect`, a regular card enrollment flow will be started, for your Select Transactions program (usually used by Loyalty applications).
+
+#### Parameters
+- `startingViewController: UIViewController`: the `UIViewController` that will start the card enrollment flow. This is a *mandatory* parameter.
+
+### verifyCard(from:cardVerificationConfiguration:)
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._ Useful only for cards enrolled in a Transaction Stream program.
+
+## Callbacks
+
+The iOS SDK provides the following callbacks:
+
+### onResult
+
+Will be called when a `FidelResult` is available, during the card enrollment process. It can be called multiple times with different types of results.
+
+#### enum FidelResult
+
+Cases:
+
+- `enrollmentResult(EnrollmentResult)`: Received after successfully enrolling the card in your Fidel API program. Please check more details about `EnrollmentResult` below.
+- `verificationResult(VerificationResult)`. _Not useful for Loyalty/Select Transactions use cases, at the moment._
+- `error(FidelError)`. An error occurred during the card enrollment process. Please check more details about `FidelError` below.
+
+#### struct EnrollmentResult
+
+A result that can be received via the `onResult` callback, after a card is successfully enrolled in your Fidel API program.
+
+Properties:
+- `cardID: String`: The identifier of the card enrolled with your Fidel API program.
+- `accountID: String`: The Fidel API account identifier.
+- `programID: String`: The identifier of the program that the card was enrolled into.
+- `enrollmentDate: Date`: The date when the card was enrolled.
+- `scheme: CardScheme`: The enrolled card's scheme.
+- `isLive: Bool`: This property will be `true` when your Fidel API account is live and the card was enrolled in your `live` Fidel API program. If the program that you enrolled the card into is not a `live` one, then this property will be `false`.
+- `cardFirstNumbers: String?`: If available, this property will be populated with the first 6 numbers of the enrolled card. To turn on or off receiving these numbers, please check your Fidel API account's settings.
+- `cardLastNumbers: String?`: If available, this property will be populated with the last 4 numbers of the enrolled card. To turn on or off receiving these numbers, please check your Fidel API account's settings.
+- `cardExpirationYear: Int`: The expiration year of the enrolled card. The values are four digit year values (ex: 2031), **not** shortened, two digit values (ex: 31).
+- `cardExpirationMonth: Int`: The expiration month of the enrolled card. The values start with `1` (January) and end with `12` (December).
+- `cardIssuingCountry: Country`: The country where the enrolled card was issued.
+- `metaData: [String: Any]?`: Custom data assigned to the enrolled card via the `metaData` SDK property.
+
+#### struct VerificationResult
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+#### struct FidelError
+
+A FidelError can occur during the card enrollment process. You can handle it via the `onResult` callback.
+
+Properties:
+
+- `message: String`: An error message explaining more details about the error. It is not localized.
+- `date: Date`: When the error occurred.
+- `type: FidelErrorType`: The type of the error. Please check more details about `FidelErrorType` below.
+
+#### enum FidelErrorType
+
+Cases:
+
+- `sdkConfigurationError`: The SDK [properties](#properties) configuration is incorrect or incomplete. You can receive this error as soon as you attempt to start a flow using the SDK [methods](#methods).
+- `userCanceled`: The user canceled the card enrollment flow.
+- `deviceNotSecure`: The device that the SDK is running on is not secure (for example, when it is jailbroken).
+- `enrollmentError(EnrollmentError)`. An error that is received during card enrollment or during consent creation. Please check more details about `EnrollmentError` below.
+- `verificationError(VerificationError)`. _Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+#### enum EnrollmentError
+
+An enum containing some of the cases of card enrollment errors.
+
+Cases:
+
+- `cardAlreadyExists`: The card was already enrolled in your Fidel API program. This error is equivalent to the Fidel API error with the code `map.already.exists`.
+- `invalidProgramID`: The program ID used to configure the SDK is not valid. If you receive this error, please make sure that you set a valid program ID via the `programID` property. This error is equivalent to the Fidel API error with the code `map.already.exists`.
+- `invalidSDKKey`: The SDK Key used to configure the Fidel SDK is not valid. If you receive this error, please make sure that you set a valid SDK Key via the `sdkKey` property. This error is equivalent to the Fidel API error with the code `credential`.
+- `inexistentProgram`: The program ID used to configure the Fidel SDK is of a program that does not exist. If you receive this error, please make sure that you set the correct program ID via the `programID` property. This error is equivalent to the Fidel API error with the code `item-exists`.
+- `unauthorized`: The card enrollment process is not authorized. This error is equivalent to the Fidel API error with the code `Unauthorized`.
+- `unexpected`: An unexpected error during the card enrollment step.
+
+The following list of cases are _not used_ by Loyalty/Select Transactions use cases, at the moment, so you can ignore them:
+
+- `issuerProcessingError`
+- `duplicateTransactionError`
+- `insufficientFundsError`
+- `processingChargeError`
+- `cardDetailsError`
+- `cardLimitExceededError`
+
+### onCardVerificationStarted
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._
+
+### onCardVerificationChoiceSelected _(!Experimental)_
+
+_Not useful for Loyalty/Select Transactions use cases, at the moment._

--- a/select/sdks/react-native/reference.md
+++ b/select/sdks/react-native/reference.md
@@ -34,7 +34,7 @@ This key is used to authenticate your Fidel API account. Get it from your Fidel 
 
 The program ID indicates the Fidel API program in which the cards will be enrolled. Get the program ID by navigating to the Fidel API dashboard -> Programs section -> Click on the ID of the program you want to use. Clicking on it will copy the ID in your pasteboard.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Loyalty use case work with your Transaction Select program, please consider setting them correctly. The following is an example:
 

--- a/stream/sdks/ios/reference.md
+++ b/stream/sdks/ios/reference.md
@@ -37,7 +37,7 @@ The maximum number of characters allowed for this property is `60`.
 
 By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Expense Management use case work with your Transaction Stream program, please consider setting them correctly.
 
@@ -245,7 +245,7 @@ Properties:
 
 #### struct FidelError
 
-A FidelError can occur during the card enrollment, card consent creation or card verification processes. You can handle them via the `onResult` callback.
+A FidelError can occur during the card enrollment, card consent creation or card verification processes. You can handle it via the `onResult` callback.
 
 Properties:
 

--- a/stream/sdks/react-native/reference.md
+++ b/stream/sdks/react-native/reference.md
@@ -210,7 +210,7 @@ Expected type: `string`
 
 By setting this property we add a link to your Terms & Conditions in the consent text. The cardholder needs to read and agree with your terms, before enrolling a card.
 
-### Optional properties (but we recommend to set them)
+### Optional properties (but we recommend setting them)
 
 The following properties are technically not mandatory to be set. However, in order to make your Expense Management use case work with your Transaction Stream program, please consider setting them correctly.
 
@@ -439,7 +439,7 @@ Properties:
 
 #### Error result object
 
-An error can occur during the card enrollment, card consent creation or card verification processes. You can handle the errors via the main results callback of the SDK.
+An error can occur during the card enrollment, card consent creation or card verification processes. You can handle it via the main results callback of the SDK.
 
 Properties:
 


### PR DESCRIPTION
Changelog:
- Clarify a few more things in the stream docs
- Add v2 iOS SDK docs for Select Transactions (Guide + Reference)
- Add clearer, more "for dummies” instructions about testing the docs, in the README file

#### Steps to test

- Go to the website project.
- Run `env DOCS_BRANCH=this-pr-branch yarn docs` to download the docs files from this PR.
- Run `yarn start` and go to `/docs` to check the changes.
